### PR TITLE
docs(readme): fix pre_bump_hooks example

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,8 +397,8 @@ You can run pre bump commands with the `{{version}}` alias to reference the newl
 ```toml
 # cog.toml
 pre_bump_hooks = [
-    "cargo build --release",
     "cargo bump {{version}}",
+    "cargo build --release",
 ]
 ```
 


### PR DESCRIPTION
small change, and maybe i was just doing it incorrectly, but the way it is currently causes the lock file to be updated _after_ the bump commit is done which throws off doing an auto release with `cargo build --release --locked`. this change suggests doing it the other way around, so that `Cargo.toml` and `Cargo.lock` both get the correct version.