### PR TITLE
fix: support annotated tags in cog check -l

### DIFF
--- a/cog.toml
+++ b/cog.toml
@@ -53,4 +53,5 @@ authors = [
     { signature = "orhun", username = "orhun" },
     { signature = "Danny Tatom", username = "its-danny" },
     { signature = "Clément Poissonnier", username = "cpoissonnier" },
+    { signature = "Luke Hsiao", username = "lukehsiao" },
 ]


### PR DESCRIPTION
Annotated tags are unique git objects with their own hashes.
Consequently, prior to this commit, cog check would not recognize these
tags in the commit ranges it checked.

This commit fixes this bug by detecting if a tag is an annotated tag,
and identifying its associated commit.

Fixes #151.