### PR TITLE
Duplicate 'coco' as 'cog commit'

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ description = """
 Cocogitto is a set of cli tools for the conventional commit
 and semver specifications.
 """
+autobins = false
 
 [profile.release]
 opt-level = 2

--- a/src/bin/cog_commit.rs
+++ b/src/bin/cog_commit.rs
@@ -1,0 +1,100 @@
+use std::fmt::Write;
+
+use cocogitto::COMMITS_METADATA;
+
+use anyhow::{bail, Result};
+use conventional_commit_parser::commit::Separator;
+use itertools::Itertools;
+
+pub fn commit_types() -> Vec<&'static str> {
+    COMMITS_METADATA
+        .iter()
+        .map(|(commit_type, _)| commit_type.as_ref())
+        .collect()
+}
+
+pub fn edit_message(
+    typ: &str,
+    message: &str,
+    scope: Option<&str>,
+    breaking: bool,
+) -> Result<(Option<String>, Option<String>, bool)> {
+    let template = prepare_edit_template(typ, message, scope, breaking);
+
+    let edited = edit::edit(&template)?;
+
+    if edited.lines().all(|line| {
+        let trimmed = line.trim_start();
+        trimmed.is_empty() || trimmed.starts_with('#')
+    }) {
+        bail!("Aborted commit message edit");
+    }
+
+    let content = edited
+        .lines()
+        .filter(|&line| !line.trim_start().starts_with('#'))
+        .join("\n");
+
+    let cc = conventional_commit_parser::parse(content.trim())?;
+
+    let footers: Option<String> = if cc.footers.is_empty() {
+        None
+    } else {
+        Some(
+            cc.footers
+                .iter()
+                .map(|footer| {
+                    let separator = match footer.token_separator {
+                        Separator::Colon => ": ",
+                        Separator::Hash => " #",
+                        Separator::ColonWithNewLine => " \n",
+                    };
+                    format!("{}{}{}", footer.token, separator, footer.content)
+                })
+                .join("\n"),
+        )
+    };
+
+    Ok((
+        cc.body.map(|s| s.trim().to_string()),
+        footers,
+        cc.is_breaking_change || breaking,
+    ))
+}
+
+const EDIT_TEMPLATE: &str = "# Enter the commit message for your changes.
+# Lines starting with # will be ignored, and empty body/footer are allowed.
+# Once you are done, save the changes and exit the editor.
+# Remove all non-comment lines to abort.
+#
+";
+
+fn prepare_header(typ: &str, message: &str, scope: Option<&str>) -> String {
+    let mut header = typ.to_string();
+
+    if let Some(scope) = scope {
+        write!(&mut header, "({})", scope).unwrap();
+    }
+
+    write!(&mut header, ": {}", message).unwrap();
+
+    header
+}
+
+fn prepare_edit_template(typ: &str, message: &str, scope: Option<&str>, breaking: bool) -> String {
+    let mut template: String = EDIT_TEMPLATE.into();
+    let header = prepare_header(typ, message, scope);
+
+    if breaking {
+        template.push_str("# WARNING: This will be marked as a breaking change!\n");
+    }
+
+    write!(
+        &mut template,
+        "{}\n\n# Message body\n\n\n# Message footer\n# For example, foo: bar\n\n\n",
+        header
+    )
+    .unwrap();
+
+    template
+}

--- a/src/bin/cog_commit.rs
+++ b/src/bin/cog_commit.rs
@@ -1,3 +1,4 @@
+#![cfg(not(tarpaulin_include))]
 use std::fmt::Write;
 
 use cocogitto::COMMITS_METADATA;

--- a/tests/cog_tests/commit.rs
+++ b/tests/cog_tests/commit.rs
@@ -1,0 +1,83 @@
+use std::process::Command;
+
+use crate::helpers::*;
+
+use anyhow::Result;
+use assert_cmd::prelude::*;
+use sealed_test::prelude::*;
+
+#[sealed_test]
+fn commit_ok() -> Result<()> {
+    // Arrange
+    git_init()?;
+    git_add("content", "test_file")?;
+
+    // Act
+    Command::cargo_bin("cog")?
+        .arg("commit")
+        .arg("feat")
+        .arg("this is a commit message")
+        .arg("scope")
+        // Assert
+        .assert()
+        .success();
+    Ok(())
+}
+
+#[sealed_test]
+fn unstaged_changes_commit_err() -> Result<()> {
+    // Arrange
+    git_init()?;
+    std::fs::write("test_file", "content")?;
+
+    // Act
+    Command::cargo_bin("cog")?
+        .arg("commit")
+        .arg("feat")
+        .arg("this is a commit message")
+        .arg("scope")
+        .arg("this is the body")
+        .arg("this is the footer")
+        // Assert
+        .assert()
+        .failure();
+    Ok(())
+}
+
+#[sealed_test]
+fn untracked_changes_commit_ok() -> Result<()> {
+    // Arrange
+    git_init()?;
+    git_add("content", "staged")?;
+    std::fs::write("untracked", "content")?;
+
+    // Act
+    Command::cargo_bin("cog")?
+        .arg("commit")
+        .arg("feat")
+        .arg("this is a commit message")
+        .arg("scope")
+        // Assert
+        .assert()
+        .success();
+    Ok(())
+}
+
+#[sealed_test]
+fn empty_commit_err() -> Result<()> {
+    // Arrange
+    git_init()?;
+
+    // Act
+    Command::cargo_bin("cog")?
+        .arg("commit")
+        .arg("feat")
+        .arg("this is a commit message")
+        .arg("scope")
+        .arg("this is the body")
+        .arg("this is the footer")
+        // Assert
+        .assert()
+        .failure();
+    Ok(())
+}

--- a/tests/cog_tests/mod.rs
+++ b/tests/cog_tests/mod.rs
@@ -2,5 +2,6 @@
 mod bump;
 mod changelog;
 mod check;
+mod commit;
 mod init;
 mod verify;


### PR DESCRIPTION
Closes #157 

The common `coco` utils have been moved to a separate `cog_commit` module, to avoid code duplication.

Adds a deprecation warning to `coco`'s help as well as prints it to stderr before starting its logic.

Should be a backwards-compatible feature, with the option to remove `coco` at a breaking change bump.