### PR TITLE
Fix broken tests

### DIFF
--- a/src/git/commit.rs
+++ b/src/git/commit.rs
@@ -47,9 +47,9 @@ mod test {
     fn create_commit_ok() -> Result<()> {
         // Arrange
         run_cmd!(
-            git init
-            echo changes > file
-            git add .
+            git init;
+            echo changes > file;
+            git add .;
         )?;
 
         let repo = Repository::open(".")?;
@@ -65,11 +65,11 @@ mod test {
     #[sealed_test]
     fn first_commit_custom_branch() {
         // Arrange
-        run_cmd! {
+        run_cmd!(
             git init -b main;
             echo changes > file;
             git add .;
-        }
+        )
         .expect("could not initialize git repository");
 
         let repo = Repository::open(".").expect("could not open git repository");
@@ -98,8 +98,8 @@ mod test {
     fn not_create_empty_commit_with_unstaged_changed() -> Result<()> {
         // Arrange
         run_cmd!(
-            git init
-            echo changes > file
+            git init;
+            echo changes > file;
         )?;
 
         let repo = Repository::open(".")?;

--- a/src/git/diff.rs
+++ b/src/git/diff.rs
@@ -39,9 +39,9 @@ mod test {
     fn get_diff_some() -> Result<()> {
         // Arrange
         run_cmd!(
-            git init
-            echo changes > file
-            git add .
+            git init;
+            echo changes > file;
+            git add .;
         )?;
 
         let repo = Repository::open(".")?;
@@ -58,8 +58,8 @@ mod test {
     fn get_diff_none() -> Result<()> {
         // Arrange
         run_cmd!(
-            git init
-            echo changes > file
+            git init;
+            echo changes > file;
         )?;
 
         let repo = Repository::open(".")?;
@@ -76,8 +76,8 @@ mod test {
     fn get_diff_include_untracked_some() -> Result<()> {
         // Arrange
         run_cmd!(
-            git init
-            echo changes > file
+            git init;
+            echo changes > file;
         )?;
 
         let repo = Repository::open(".")?;

--- a/src/git/repository.rs
+++ b/src/git/repository.rs
@@ -134,9 +134,9 @@ mod test {
     fn get_repo_head_oid_ok() -> Result<()> {
         // Arrange
         run_cmd!(
-            git init
-            echo changes > file
-            git add .
+            git init;
+            echo changes > file;
+            git add .;
         )?;
         let repo = Repository::open(".")?;
         let commit_oid = repo.commit("first commit")?;
@@ -166,9 +166,9 @@ mod test {
     fn get_repo_head_obj_ok() -> Result<()> {
         // Arrange
         run_cmd!(
-            git init
-            echo changes > file
-            git add .
+            git init;
+            echo changes > file;
+            git add .;
         )?;
         let repo = Repository::open(".")?;
         let commit_oid = repo.commit("first commit")?;
@@ -185,9 +185,9 @@ mod test {
     fn get_repo_head_obj_err() -> Result<()> {
         // Arrange
         run_cmd!(
-            git init
-            echo changes > file
-            git add .
+            git init;
+            echo changes > file;
+            git add .;
         )?;
         let repo = Repository::open(".")?;
 
@@ -203,9 +203,9 @@ mod test {
     fn get_head_some() -> Result<()> {
         // Arrange
         run_cmd!(
-            git init
-            echo changes > file
-            git add .
+            git init;
+            echo changes > file;
+            git add .;
         )?;
         let repo = Repository::open(".")?;
 
@@ -223,9 +223,9 @@ mod test {
     fn get_head_none() -> Result<()> {
         // Arrange
         run_cmd!(
-            git init
-            echo changes > file
-            git add .
+            git init;
+            echo changes > file;
+            git add .;
         )?;
 
         let repo = Repository::open(".")?;
@@ -242,9 +242,9 @@ mod test {
     fn get_branch_short_hand() -> Result<()> {
         // Arrange
         run_cmd!(
-            git init
-            echo changes > file
-            git add .
+            git init;
+            echo changes > file;
+            git add .;
         )?;
         let repo = Repository::open(".")?;
         repo.commit("hello one")?;

--- a/src/git/revspec.rs
+++ b/src/git/revspec.rs
@@ -379,17 +379,17 @@ mod test {
         // Arrange
         let repo = Repository::init(".")?;
         run_cmd!(
-            git init
-            echo changes > file
-            git add .
+            git init;
+            echo changes > file;
+            git add .;
         )?;
 
         let start = repo.commit("chore: init")?;
 
         run_cmd!(
-            git init
-            echo changes > file2
-            git add .
+            git init;
+            echo changes > file2;
+            git add .;
         )?;
 
         let _end = repo.commit("chore: 1.0.0")?;
@@ -401,9 +401,9 @@ mod test {
             .tag("1.0.0", &head.into_object(), &sig, "the_msg", false)?;
 
         run_cmd!(
-            git init
-            echo changes > file3
-            git add .
+            git init;
+            echo changes > file3;
+            git add .;
         )?;
 
         repo.commit("feat: a commit")?;
@@ -421,17 +421,17 @@ mod test {
         // Arrange
         let repo = Repository::init(".")?;
         run_cmd!(
-            git init
-            echo changes > file
-            git add .
+            git init;
+            echo changes > file;
+            git add .;
         )?;
 
         let start = repo.commit("chore: init")?;
 
         run_cmd!(
-            git init
-            echo changes > file2
-            git add .
+            git init;
+            echo changes > file2;
+            git add .;
         )?;
 
         let _end = repo.commit("chore: 1.0.0")?;
@@ -439,9 +439,9 @@ mod test {
         repo.create_tag("1.0.0")?;
 
         run_cmd!(
-            git init
-            echo changes > file3
-            git add .
+            git init;
+            echo changes > file3;
+            git add .;
         )?;
 
         repo.commit("feat: a commit")?;

--- a/src/git/tag.rs
+++ b/src/git/tag.rs
@@ -180,8 +180,8 @@ mod test {
         // Arrange
         let repo = Repository::init(".")?;
         run_cmd!(
-            git commit -m allow-empty -m "first commit"
-            git tag the_tag
+            git commit -m allow-empty -m "first commit";
+            git tag the_tag;
         )?;
 
         // Act
@@ -197,8 +197,8 @@ mod test {
         // Arrange
         let repo = Repository::init(".")?;
         run_cmd!(
-            git commit -m allow-empty -m "first commit"
-            git tag the_tag
+            git commit -m allow-empty -m "first commit";
+            git tag the_tag;
         )?;
 
         // Act
@@ -214,10 +214,10 @@ mod test {
         // Arrange
         let repo = Repository::init(".")?;
         run_cmd!(
-            git commit -m allow-empty -m "first commit"
-            git tag 0.1.0
-            git commit -m allow-empty -m "second commit"
-            git tag 0.2.0
+            git commit -m allow-empty -m "first commit";
+            git tag 0.1.0;
+            git commit -m allow-empty -m "second commit";
+            git tag 0.2.0;
         )?;
 
         // Act
@@ -249,8 +249,8 @@ mod test {
         // Arrange
         let repo = Repository::init(".")?;
         run_cmd!(
-            git commit -m allow-empty -m "first commit"
-            git tag 0.1.0
+            git commit -m allow-empty -m "first commit";
+            git tag 0.1.0;
         )?;
 
         // Act


### PR DESCRIPTION
As discussed in #177, the combination of two issues causes many tests to pass, even when errors occur.
Here I added all the missing ";" in the tests. 
While this might fix the test logic, the real problem is that returning an `Err` from the tests does not fail them.
Not sure if this is enough to merge, or should we wait until the tests are entirely fixed? Up to you, @oknozor.