### PR TITLE
fix: build commit type error regardless of the command used

### DIFF
--- a/src/hook/mod.rs
+++ b/src/hook/mod.rs
@@ -54,8 +54,7 @@ impl VersionSpan {
         let version = version.to_version()?;
         let latest = latest
             .map(|version| version.to_version())
-            .map(Result::ok)
-            .flatten();
+            .and_then(Result::ok);
 
         // According to the pest grammar, a `version` or `latest_version` token is expected first
         let mut version = match self.tokens.pop_front() {


### PR DESCRIPTION
This should fix the issue where cog edit does not pick the type errors. 
 
A test is needed to ensure there is no cog check regression
Also cog edit should be tested manually since it relies on the user $EDITOR 
