### PR TITLE
fix: handle grafted commit for shallow clone repository

### DIFF
--- a/src/git/repository.rs
+++ b/src/git/repository.rs
@@ -47,9 +47,9 @@ impl Repository {
         let mut revwalk = self.0.revwalk()?;
         revwalk.push_head()?;
         revwalk
+            .flatten()
             .last()
-            .ok_or_else(|| anyhow!("Could not find commit"))?
-            .map_err(|err| anyhow!(err))
+            .ok_or_else(|| anyhow!("Could not find first commit"))
     }
 
     pub(crate) fn get_head(&self) -> Option<Object> {

--- a/src/git/revspec.rs
+++ b/src/git/revspec.rs
@@ -71,9 +71,10 @@ impl Repository {
         revwalk.push_head()?;
         let mut commits = vec![];
 
-        for oid in revwalk {
-            let commit = self.0.find_commit(oid?)?;
-            commits.push(commit);
+        for oid in revwalk.flatten() {
+            if let Ok(commit) = self.0.find_commit(oid) {
+                commits.push(commit);
+            }
         }
 
         let from = commits
@@ -183,9 +184,7 @@ impl Repository {
         let to = maybe_to_tag
             .map(OidOf::Tag)
             .unwrap_or_else(|| OidOf::Other(to));
-
         let commits = self.get_commit_range_from_spec(&spec)?;
-
         Ok(CommitRange { from, to, commits })
     }
 
@@ -218,8 +217,7 @@ impl Repository {
 
         let mut commits: Vec<Commit> = vec![];
 
-        for oid in revwalk {
-            let oid = oid?;
+        for oid in revwalk.flatten() {
             let commit = self.0.find_commit(oid)?;
             commits.push(commit);
         }

--- a/tests/cog_tests/check.rs
+++ b/tests/cog_tests/check.rs
@@ -2,8 +2,12 @@ use crate::helpers::*;
 
 use anyhow::Result;
 use assert_cmd::Command;
+use cmd_lib::{init_builtin_logger, run_cmd};
+use cocogitto::CocoGitto;
 use predicates::prelude::predicate;
 use sealed_test::prelude::*;
+use speculoos::assert_that;
+use speculoos::prelude::ResultAssertions;
 
 #[sealed_test]
 fn cog_check_ok() -> Result<()> {
@@ -81,5 +85,143 @@ fn cog_check_from_latest_tag_failure() -> Result<()> {
         .assert()
         .failure()
         .stderr(predicate::str::contains("Found 1 non compliant commits"));
+    Ok(())
+}
+
+#[sealed_test]
+fn shallow_clone_check_err() -> Result<()> {
+    // Arrange
+    init_builtin_logger();
+    let current_dir = std::env::current_dir()?;
+    let current_dir = current_dir.to_str().expect("Cannot get current directory");
+    let a = format!("file://{current_dir}/a");
+
+    run_cmd!(
+        mkdir a;
+        cd a;
+        git init;
+        git commit --allow-empty -m "feat: Add the 1 feature";
+        git commit --allow-empty -m "feat: Add the 2 feature";
+        git commit --allow-empty -m "feat: Add the 3 feature";
+        git commit --allow-empty -m "feat: Add the 4 feature";
+        git commit --allow-empty -m "feat: Add the 5 feature";
+        cd $current_dir;
+        git clone --depth 3 "$a" b;
+    )?;
+
+    std::env::set_current_dir("b")?;
+
+    let cocogitto = CocoGitto::get()?;
+
+    // Act
+    let check_result = cocogitto.check(false);
+
+    // Assert
+    assert_that!(check_result).is_ok();
+
+    Ok(())
+}
+
+#[sealed_test]
+fn shallow_clone_check_ok() -> Result<()> {
+    // Arrange
+    init_builtin_logger();
+    let current_dir = std::env::current_dir()?;
+    let current_dir = current_dir.to_str().expect("Cannot get current directory");
+    let a = format!("file://{current_dir}/a");
+
+    run_cmd!(
+        mkdir a;
+        cd a;
+        git init;
+        git commit --allow-empty -m "feat: Add the 1 feature";
+        git commit --allow-empty -m "feat: Add the 2 feature";
+        git commit --allow-empty -m "feat: Add the 3 feature";
+        git commit --allow-empty -m "feat: Add the 4 feature";
+        git commit --allow-empty -m "toto";
+        cd $current_dir;
+        git clone --depth 3 "$a" b;
+    )?;
+
+    std::env::set_current_dir("b")?;
+
+    // Act
+    let cocogitto = CocoGitto::get()?;
+
+    let result = cocogitto.check(false);
+
+    // Assert
+    assert_that!(result).is_err();
+
+    Ok(())
+}
+
+#[sealed_test]
+fn shallow_clone_from_latest_tag_check_ok() -> Result<()> {
+    // Arrange
+    init_builtin_logger();
+    let current_dir = std::env::current_dir()?;
+    let current_dir = current_dir.to_str().expect("Cannot get current directory");
+    let a = format!("file://{current_dir}/a");
+
+    run_cmd!(
+        mkdir a;
+        cd a;
+        git init;
+        git commit --allow-empty -m "feat: Add the 1 feature";
+        git commit --allow-empty -m "feat: Add the 2 feature";
+        git tag 1.0.0;
+        git commit --allow-empty -m "feat: Add the 3 feature";
+        git commit --allow-empty -m "feat: Add the 4 feature";
+        git commit --allow-empty -m "feat: Add the 5 feature";
+        cd $current_dir;
+        git clone --depth 3 "$a" b;
+    )?;
+
+    std::env::set_current_dir("b")?;
+
+    // Act
+    let cocogitto = CocoGitto::get()?;
+
+    let check_result = cocogitto.check(true);
+
+    // Assert
+    assert_that!(check_result).is_ok();
+
+    Ok(())
+}
+
+#[sealed_test]
+fn shallow_clone_from_latest_tag_check_err() -> Result<()> {
+    // Arrange
+    init_builtin_logger();
+    let current_dir = std::env::current_dir()?;
+    let current_dir = current_dir.to_str().expect("Cannot get current directory");
+    let a = format!("file://{current_dir}/a");
+
+    run_cmd!(
+        mkdir a;
+        cd a;
+        git init;
+        git commit --allow-empty -m "feat: Add the 1 feature";
+        git commit --allow-empty -m "feat: Add the 2 feature";
+        git tag 1.0.0;
+        git commit --allow-empty -m "feat: Add the 3 feature";
+        git commit --allow-empty -m "feat: Add the 4 feature";
+        git commit --allow-empty -m "toto";
+        cd $current_dir;
+        git clone --depth 3 "$a" b;
+    )?;
+
+    std::env::set_current_dir("b")?;
+
+    let cocogitto = CocoGitto::get()?;
+
+    // Act
+    let check_result = cocogitto.check(true);
+
+    // Assert
+    assert_that!(check_result).is_err();
+
     Ok(())
 }


### PR DESCRIPTION
Shallow clone is not supported yet in libgit2 (https://github.com/rust-lang/git2-rs/issues/796).
The starting (grafted) commit oid of a shallow clone repository can be seen but is not accessible.
A quick fix for this is to check weither the starting commit is reachable and fallback to the first
reachable one if not.

closes #173