### PR TITLE
feat: add the ability to forbid merge commit via configuration

### DIFF
--- a/src/bin/cog.rs
+++ b/src/bin/cog.rs
@@ -77,6 +77,9 @@ enum Cli {
     Verify {
         /// The commit message
         message: String,
+        /// Ignore merge commit or lint them
+        #[clap(short = 'i', long)]
+        ignore_merge_commit: bool,
     },
 
     /// Display a changelog for the given commit oid range
@@ -209,12 +212,21 @@ fn main() -> Result<()> {
 
             cocogitto.create_version(increment, pre.as_deref(), hook_profile.as_deref())?
         }
-        Cli::Verify { message } => {
+        Cli::Verify {
+            message,
+            ignore_merge_commit,
+        } => {
             let author = CocoGitto::get()
                 .map(|cogito| cogito.get_committer().unwrap())
                 .ok();
 
-            commit::verify(author, &message)?;
+            let ignore_merge_commit = if ignore_merge_commit {
+                true
+            } else {
+                SETTINGS.ignore_merge_commit
+            };
+
+            commit::verify(author, &message, ignore_merge_commit)?;
         }
         Cli::Check { from_latest_tag } => {
             let cocogitto = CocoGitto::get()?;

--- a/src/conventional/changelog/release.rs
+++ b/src/conventional/changelog/release.rs
@@ -5,7 +5,7 @@ use serde::Serialize;
 use crate::conventional::commit::Commit;
 use crate::git::oid::OidOf;
 use crate::git::revspec::CommitRange;
-use crate::settings;
+use crate::{settings, SETTINGS};
 use colored::Colorize;
 
 #[derive(Debug, Serialize)]
@@ -23,9 +23,11 @@ impl<'a> From<CommitRange<'a>> for Release<'a> {
 
         for commit in commit_range.commits {
             // Ignore merge commits
-            if let Some(message) = commit.message() {
-                if message.starts_with("Merge") {
-                    continue;
+            if SETTINGS.ignore_merge_commit {
+                if let Some(message) = commit.message() {
+                    if message.starts_with("Merge branch") {
+                        continue;
+                    }
                 }
             }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -220,7 +220,12 @@ impl CocoGitto {
                             .collect();
 
                         rebase.commit(None, &original_commit.committer(), Some(&new_message))?;
-                        match verify(self.repository.get_author().ok(), &new_message) {
+                        let ignore_merge_commit = SETTINGS.ignore_merge_commit;
+                        match verify(
+                            self.repository.get_author().ok(),
+                            &new_message,
+                            ignore_merge_commit,
+                        ) {
                             Ok(_) => println!(
                                 "Changed commit message to:\"{}\"",
                                 &new_message.trim_end()

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -29,6 +29,8 @@ pub struct Settings {
     pub branch_whitelist: Vec<String>,
     pub tag_prefix: Option<String>,
     #[serde(default)]
+    pub ignore_merge_commit: bool,
+    #[serde(default)]
     pub pre_bump_hooks: Vec<String>,
     #[serde(default)]
     pub post_bump_hooks: Vec<String>,

--- a/tests/cog_tests/verify.rs
+++ b/tests/cog_tests/verify.rs
@@ -73,3 +73,36 @@ fn verify_fails() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn verify_fails_on_merge_commit() -> Result<()> {
+    // Arrange
+    let message = "Merge branch 'main' of github.com:thalo-rs/thalo into dev";
+
+    // Act
+    Command::cargo_bin("cog")?
+        .arg("verify")
+        .arg(message)
+        // Assert
+        .assert()
+        .failure();
+
+    Ok(())
+}
+
+#[test]
+fn verify_ignores_merge_commit() -> Result<()> {
+    // Arrange
+    let message = "Merge branch 'main' of github.com:thalo-rs/thalo into dev";
+
+    // Act
+    Command::cargo_bin("cog")?
+        .arg("verify")
+        .arg("--ignore-merge-commit")
+        .arg(message)
+        // Assert
+        .assert()
+        .success();
+
+    Ok(())
+}


### PR DESCRIPTION
This commit add the possibility to configure "ignore_merge_commit = false" to completely forbid
the usage of merge commit with a non conventional commit message. This also fix inconsistency
between 'cog verify' and 'cog check' which previously behaved differently with merge commits. 

closes  #166