### PR TITLE
docs: suggest running a locked install when using cargo

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ pacman -S cocogitto
 #### Cargo
 
 ```shell
-cargo install cocogitto
+cargo install --locked cocogitto
 ```
 
 #### NixOs


### PR DESCRIPTION
Just tried `cargo install cocogitto` and it failed because it tried to use deps that were too new 😄