### PR TITLE
chore: use cargo-edit for bumping crate version

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -25,7 +25,7 @@ jobs:
           toolchain: stable
 
       - run: 
-          cargo install cargo-bump
+          cargo install cargo-edit
 
       - run:
           cargo login ${{secrets.CARGO_TOKEN}}

--- a/cog.toml
+++ b/cog.toml
@@ -6,7 +6,7 @@ pre_bump_hooks = [
     "cargo test",
     "cargo clippy",
     "cargo fmt --all",
-    "cargo bump {{version}}",
+    "cargo set-version {{version}}",
     "cargo build --release",
 ]
 


### PR DESCRIPTION
`cargo-bump` seems stale since 2019, switching to a newer crate would set a good example for users