### PR TITLE
fix: avoid using the format ident capturing Rust feature

### DIFF
--- a/src/conventional/changelog/error.rs
+++ b/src/conventional/changelog/error.rs
@@ -15,10 +15,14 @@ impl Display for ChangelogError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             ChangelogError::TemplateNotFound(path) => {
-                writeln!(f, "changelog template not found in {path:?}")
+                writeln!(f, "changelog template not found in {:?}", path)
             }
-            ChangelogError::TeraError(err) => writeln!(f, "failed to render changelog: \n\t{err}"),
-            ChangelogError::WriteError(err) => writeln!(f, "failed to write changelog: \n\t{err}"),
+            ChangelogError::TeraError(err) => {
+                writeln!(f, "failed to render changelog: \n\t{}", err)
+            }
+            ChangelogError::WriteError(err) => {
+                writeln!(f, "failed to write changelog: \n\t{}", err)
+            }
             ChangelogError::SeparatorNotFound(path) => writeln!(
                 f,
                 "cannot find default separator '- - -' in {}",

--- a/src/conventional/error.rs
+++ b/src/conventional/error.rs
@@ -34,9 +34,9 @@ impl Display for BumpError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         writeln!(f, "failed to bump version\n")?;
         match self {
-            BumpError::Git2Error(err) => writeln!(f, "\t{err}"),
-            BumpError::TagError(err) => writeln!(f, "\t{err}"),
-            BumpError::SemVerError(err) => writeln!(f, "\t{err}"),
+            BumpError::Git2Error(err) => writeln!(f, "\t{}", err),
+            BumpError::TagError(err) => writeln!(f, "\t{}", err),
+            BumpError::SemVerError(err) => writeln!(f, "\t{}", err),
             BumpError::NoCommitFound => writeln!(
                 f,
                 r#"cause: No conventional commit found to bump current version.
@@ -80,13 +80,18 @@ impl Display for ConventionalCommitError {
                 let error_header = "Errored commit: ".bold().red();
                 let author = format!("<{}>", author).blue();
                 let cause = anyhow!(cause.clone());
-                let cause = format!("{cause:?}")
+                let cause = format!("{:?}", cause)
                     .lines()
                     .collect::<Vec<&str>>()
                     .join("\n\t");
 
                 writeln!(
-                    f, "{error_header}{oid} {author}\n\t{message_title}'{summary}'\n\t{cause_title}{cause}",
+                    f,
+                    "{}{} {}\n\t{message_title}'{summary}'\n\t{cause_title}{}",
+                    error_header,
+                    oid,
+                    author,
+                    cause,
                     message_title = "Commit message: ".yellow().bold(),
                     summary = summary.italic(),
                     cause_title = "Error: ".yellow().bold(),
@@ -99,10 +104,13 @@ impl Display for ConventionalCommitError {
                 author,
             } => {
                 let error_header = "Errored commit: ".bold().red();
-                let author = format!("<{author}>").blue();
+                let author = format!("<{}>", author).blue();
                 writeln!(
                     f,
-                    "{error_header}{oid} {author}\n\t{message}'{summary}'\n\t{cause}Commit type `{commit_type}` not allowed",
+                    "{}{} {}\n\t{message}'{summary}'\n\t{cause}Commit type `{commit_type}` not allowed",
+                    error_header,
+                    oid,
+                    author,
                     message = "Commit message:".yellow().bold(),
                     cause = "Error:".yellow().bold(),
                     summary = summary.italic(),
@@ -111,7 +119,7 @@ impl Display for ConventionalCommitError {
             }
             ConventionalCommitError::ParseError(err) => {
                 let err = anyhow!(err.clone());
-                writeln!(f, "{err:?}")
+                writeln!(f, "{:?}", err)
             }
         }
     }

--- a/src/git/error.rs
+++ b/src/git/error.rs
@@ -75,11 +75,11 @@ impl Display for Git2Error {
         match self {
             Git2Error::NothingToCommit { branch, statuses } => {
                 if let Some(branch) = branch {
-                    writeln!(f, "On branch {branch}\n")?;
+                    writeln!(f, "On branch {}\n", branch)?;
                 }
 
                 match statuses {
-                    Some(statuses) if !statuses.0.is_empty() => write!(f, "{statuses}"),
+                    Some(statuses) if !statuses.0.is_empty() => write!(f, "{}", statuses),
                     _ => writeln!(
                         f,
                         "nothing to commit (create/copy files and use \"git add\" to track)"
@@ -109,8 +109,9 @@ impl Display for Git2Error {
             Git2Error::StatusError(_) => writeln!(f, "failed to get git statuses"),
             Git2Error::ChangesNeedToBeCommitted(statuses) => writeln!(
                 f,
-                "{}{statuses}",
-                "Cannot create tag: changes need to be committed".red()
+                "{}{}",
+                "Cannot create tag: changes need to be committed".red(),
+                statuses
             ),
         }?;
 
@@ -123,7 +124,7 @@ impl Display for Git2Error {
             | Git2Error::StashError(err)
             | Git2Error::StatusError(err)
             | Git2Error::Other(err)
-            | Git2Error::CommitNotFound(err) => writeln!(f, "\ncause: {err}"),
+            | Git2Error::CommitNotFound(err) => writeln!(f, "\ncause: {}", err),
             _ => fmt::Result::Ok(()),
         }
     }
@@ -133,23 +134,23 @@ impl Display for TagError {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
             TagError::SemVerError { tag, err } => {
-                writeln!(f, "tag `{tag}` is not SemVer compliant")?;
-                writeln!(f, "\tcause: {err}")
+                writeln!(f, "tag `{}` is not SemVer compliant", tag)?;
+                writeln!(f, "\tcause: {}", err)
             }
             TagError::InvalidPrefixError { prefix, tag } => {
-                writeln!(f, "Expected a tag with prefix {prefix}, got {tag}")
+                writeln!(f, "Expected a tag with prefix {}, got {}", prefix, tag)
             }
             TagError::NotFound { tag, err } => {
-                writeln!(f, "tag {tag} not found")?;
-                writeln!(f, "\tcause: {err}")
+                writeln!(f, "tag {} not found", tag)?;
+                writeln!(f, "\tcause: {}", err)
             }
             TagError::NoTag => writeln!(f, "unable to get any tag"),
             TagError::NoMatchFound { pattern, err } => {
                 match pattern {
                     None => writeln!(f, "no tag found")?,
-                    Some(pattern) => writeln!(f, "no tag matching pattern {pattern}")?,
+                    Some(pattern) => writeln!(f, "no tag matching pattern {}", pattern)?,
                 }
-                writeln!(f, "\tcause: {err}")
+                writeln!(f, "\tcause: {}", err)
             }
         }
     }

--- a/src/hook/mod.rs
+++ b/src/hook/mod.rs
@@ -166,7 +166,7 @@ impl Hook {
         #[cfg(target_family = "unix")]
         {
             let args = args.iter().join(" ");
-            let cmd = format!("{cmd} {args}");
+            let cmd = format!("{} {}", cmd, args);
 
             let status = Command::new("sh").arg("-c").arg(cmd).status()?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,7 @@ pub fn init<S: AsRef<Path> + ?Sized>(path: &S) -> Result<()> {
 
     if !path.exists() {
         std::fs::create_dir(&path)
-            .map_err(|err| anyhow!("failed to create directory `{path:?}` \n\ncause:{err}"))?;
+            .map_err(|err| anyhow!("failed to create directory `{:?}` \n\ncause: {}", path, err))?;
     }
 
     let mut is_init_commit = false;
@@ -96,9 +96,15 @@ pub fn init<S: AsRef<Path> + ?Sized>(path: &S) -> Result<()> {
         std::fs::write(
             &settings_path,
             toml::to_string(&settings)
-                .map_err(|err| anyhow!("failed to serialize {CONFIG_PATH}\n\ncause: {err}"))?,
+                .map_err(|err| anyhow!("failed to serialize {}\n\ncause: {}", CONFIG_PATH, err))?,
         )
-        .map_err(|err| anyhow!("failed to write file `{settings_path:?}`\n\ncause: {err}"))?;
+        .map_err(|err| {
+            anyhow!(
+                "failed to write file `{:?}`\n\ncause: {}",
+                settings_path,
+                err
+            )
+        })?;
     }
 
     repository.add_all()?;
@@ -426,7 +432,12 @@ impl CocoGitto {
                     glob.is_match(&branch)
                 });
 
-                ensure!(is_match, "No patterns matched in {whitelist:?} for branch '{branch}', bump is not allowed")
+                ensure!(
+                    is_match,
+                    "No patterns matched in {:?} for branch '{}', bump is not allowed",
+                    whitelist,
+                    branch
+                )
             }
         };
 
@@ -437,7 +448,7 @@ impl CocoGitto {
                 println!("Failed to get current version, falling back to 0.0.0");
                 Version::new(0, 0, 0)
             }
-            Err(ref err) => bail!("{err}"),
+            Err(ref err) => bail!("{}", err),
         };
 
         let mut next_version = increment.bump(&current_version, &self.repository)?;
@@ -450,7 +461,7 @@ impl CocoGitto {
                 cause_key, comparison
             );
 
-            bail!("{}:\n\t{cause}\n", "SemVer Error".red().to_string());
+            bail!("{}:\n\t{}\n", "SemVer Error".red().to_string(), cause);
         };
 
         if let Some(pre_release) = pre_release {


### PR DESCRIPTION
Should allow us to piggyback on Rust 1.56+ a little bit longer 😄