### PR TITLE
refactor(changelog): use tera whitespace escapes instead of antislash

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ clap_complete = { version = "3.0", optional = true }
 conventional_commit_parser = "0.9.4"
 pest = "2.1.3"
 pest_derive = "2.1.0"
-tera = "1.12.1"
+tera = "1.15.0"
 globset = "0.4.8"
 
 [dev-dependencies]

--- a/src/conventional/changelog/release.rs
+++ b/src/conventional/changelog/release.rs
@@ -87,7 +87,7 @@ mod test {
     use conventional_commit_parser::commit::{CommitType, ConventionalCommit, Footer};
     use git2::Oid;
     use indoc::indoc;
-    use speculoos::prelude::*;
+    use pretty_assertions::assert_eq;
 
     use crate::conventional::changelog::release::{ChangelogCommit, Release};
     use crate::conventional::changelog::renderer::Renderer;
@@ -103,26 +103,27 @@ mod test {
         let renderer = Renderer::default();
 
         // Act
-        let changelog = renderer.render(release);
+        let changelog = renderer.render(release)?;
 
         // Assert
-        assert_that!(changelog).is_ok().is_equal_to(
+        assert_eq!(
+            changelog,
             indoc! {
                 "## 1.0.0 - 2015-09-05
                 #### Bug Fixes
                 - **(parser)** fix parser implementation - (17f7e23) - *oknozor*
                 #### Features
                 - **(parser)** implement the changelog generator - (17f7e23) - *oknozor*
-                - awesome feature - (17f7e23) - Paul Delafosse"
+                - awesome feature - (17f7e23) - Paul Delafosse
+                "
             }
-            .to_string(),
         );
 
         Ok(())
     }
 
     #[test]
-    fn should_full_hash_template() -> Result<()> {
+    fn should_render_full_hash_template() -> Result<()> {
         // Arrange
         let release = Release::fixture();
         let renderer = Renderer::try_new(Template {
@@ -131,18 +132,20 @@ mod test {
         })?;
 
         // Act
-        let changelog = renderer.render(release);
+        let changelog = renderer.render(release)?;
 
         // Assert
-        assert_that!(changelog).is_ok().is_equal_to(
+        assert_eq!(
+            changelog,
             indoc! {
                 "#### Bug Fixes
                 - 17f7e23081db15e9318aeb37529b1d473cf41cbe - **(parser)** fix parser implementation - @oknozor
                 #### Features
                 - 17f7e23081db15e9318aeb37529b1d473cf41cbe - **(parser)** implement the changelog generator - @oknozor
-                - 17f7e23081db15e9318aeb37529b1d473cf41cbe - awesome feature - Paul Delafosse"
+                - 17f7e23081db15e9318aeb37529b1d473cf41cbe - awesome feature - Paul Delafosse
+
+                "
             }
-                .to_string(),
         );
 
         Ok(())
@@ -162,19 +165,20 @@ mod test {
         })?;
 
         // Act
-        let changelog = renderer.render(release);
+        let changelog = renderer.render(release)?;
 
         // Assert
-        assert_that!(changelog).is_ok().is_equal_to(
+        assert_eq!(
+            changelog,
             indoc! {
                 "## [1.0.0](https://github.com/cocogitto/cocogitto/compare/0.1.0..1.0.0) - 2015-09-05
                 #### Bug Fixes
                 - **(parser)** fix parser implementation - ([17f7e23](https://github.com/cocogitto/cocogitto/commit/17f7e23081db15e9318aeb37529b1d473cf41cbe)) - [@oknozor](https://github.com/oknozor)
                 #### Features
                 - **(parser)** implement the changelog generator - ([17f7e23](https://github.com/cocogitto/cocogitto/commit/17f7e23081db15e9318aeb37529b1d473cf41cbe)) - [@oknozor](https://github.com/oknozor)
-                - awesome feature - ([17f7e23](https://github.com/cocogitto/cocogitto/commit/17f7e23081db15e9318aeb37529b1d473cf41cbe)) - Paul Delafosse"
+                - awesome feature - ([17f7e23](https://github.com/cocogitto/cocogitto/commit/17f7e23081db15e9318aeb37529b1d473cf41cbe)) - Paul Delafosse
+                "
             }
-                .to_string(),
         );
 
         Ok(())

--- a/src/conventional/changelog/renderer.rs
+++ b/src/conventional/changelog/renderer.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
 
-use itertools::Itertools;
 use tera::{get_json_pointer, to_value, try_get_value, Context, Tera, Value};
 
 use crate::conventional::changelog::release::Release;
@@ -35,7 +34,7 @@ impl Renderer {
         let mut release = self.render_release(&version)?;
         let mut version = version;
         while let Some(previous) = version.previous.map(|v| *v) {
-            release.push_str("\n\n- - -\n\n");
+            release.push_str("\n- - -\n\n");
             release.push_str(self.render_release(&previous)?.as_str());
             version = previous;
         }
@@ -56,13 +55,6 @@ impl Renderer {
 
         self.tera
             .render(self.template.kind.name(), &template_context)
-            .map(|changelog| {
-                changelog
-                    .lines()
-                    .map(|line| line.trim())
-                    .filter(|line| *line != "\\")
-                    .join("\n")
-            })
     }
 
     // From git-cliff: https://github.com/orhun/git-cliff/blob/main/git-cliff-core/src/template.rs

--- a/src/conventional/changelog/template/full_hash
+++ b/src/conventional/changelog/template/full_hash
@@ -1,23 +1,27 @@
-{% for type, typed_commits in commits | sort(attribute="type")| group_by(attribute="type")%}                            \
-                                                                                                                        \
+{% for type, typed_commits in commits | sort(attribute="type")| group_by(attribute="type") -%}
 #### {{ type | upper_first }}
-                                                                                                                        \
-    {% for scope, scoped_commits in typed_commits | group_by(attribute="scope") %}                                      \
-        {% for commit in scoped_commits | sort(attribute="scope") %}                                                    \
-            {% if commit.author %}                                                                                      \
-                {% set author = "@" ~ commit.author %}                                                                  \
-            {% else %}                                                                                                  \
-                {% set author = commit.signature %}                                                                     \
-            {% endif %}                                                                                                 \
-            - {{ commit.id }} - **({{ scope }})** {{ commit.summary }} - {{ author }}
-        {% endfor %}                                                                                                    \
-    {% endfor %}                                                                                                        \
-    {% for commit in typed_commits | unscoped %}                                                                        \
-        {% if commit.author %}                                                                                          \
-            {% set author = "@" ~ commit.author %}                                                                      \
-        {% else %}                                                                                                      \
-            {% set author = commit.signature %}                                                                         \
-        {% endif %}                                                                                                     \
-            - {{ commit.id }} - {{ commit.summary }} - {{ author }}
-    {% endfor %}                                                                                                        \
-{% endfor %}                                                                                                            \
+{% for scope, scoped_commits in typed_commits | group_by(attribute="scope") -%}
+
+{% for commit in scoped_commits | sort(attribute="scope") -%}
+    {% if commit.author -%}
+        {% set author = "@" ~ commit.author -%}
+    {% else -%}
+        {% set author = commit.signature -%}
+    {% endif -%}
+    - {{ commit.id }} - **({{ scope }})** {{ commit.summary }} - {{ author }}
+{% endfor -%}
+
+{% endfor -%}
+
+{% for commit in typed_commits | unscoped -%}
+
+    {% if commit.author -%}
+        {% set author = "@" ~ commit.author -%}
+    {% else -%}
+        {% set author = commit.signature -%}
+    {% endif -%}
+        - {{ commit.id }} - {{ commit.summary }} - {{ author }}
+
+{% endfor -%}
+
+{% endfor -%}

--- a/src/conventional/changelog/template/remote
+++ b/src/conventional/changelog/template/remote
@@ -1,45 +1,48 @@
-{% if version.tag and from.tag %}                                                                                       \
+{% if version.tag and from.tag -%}
     ## [{{ version.tag }}]({{repository_url ~ "/compare/" ~ from.tag ~ ".." ~ version.tag}}) - {{ date | date(format="%Y-%m-%d") }}
-{% elif version.tag and from.id %}                                                                                      \
+{% elif version.tag and from.id -%}
     ## [{{ version.tag }}]({{repository_url ~ "/compare/" ~ from.id ~ ".." ~ version.tag}}) - {{ date | date(format="%Y-%m-%d") }}
-{% else %}                                                                                                              \
-    {% set from = from.id %}                                                                                            \
-    {% set to = version.id %}                                                                                           \
-                                                                                                                        \
-    {% set from_shorthand = from.id | truncate(length=7, end="") %}                                                     \
-    {% set to_shorthand = version.id | truncate(length=7, end="") %}                                                    \
-                                                                                                                        \
+{% else -%}
+    {% set from = from.id -%}
+    {% set to = version.id -%}
+
+    {% set from_shorthand = from.id | truncate(length=7, end="") -%}
+    {% set to_shorthand = version.id | truncate(length=7, end="") -%}
+
     ## Unreleased ([{{ from_shorthand ~ ".." ~ to_shorthand }}]({{repository_url ~ "/compare/" ~ from_shorthand ~ ".." ~ to_shorthand}}))
-{% endif %}                                                                                                             \
-                                                                                                                        \
-{% for type, typed_commits in commits | sort(attribute="type")| group_by(attribute="type")%}                            \
-                                                                                                                        \
+{% endif -%}
+
+{% for type, typed_commits in commits | sort(attribute="type")| group_by(attribute="type")-%}
+
 #### {{ type | upper_first }}
-                                                                                                                        \
-    {% for scope, scoped_commits in typed_commits | group_by(attribute="scope") %}                                      \
-        {% for commit in scoped_commits | sort(attribute="scope") %}                                                    \
-            {% if commit.author and repository_url %}                                                                   \
-                {% set author = "@" ~ commit.author %}                                                                  \
-                {% set author_link = platform ~ "/" ~ commit.author %}                                           \
-                {% set author = "[" ~ author ~ "](" ~ author_link ~ ")" %}                                              \
-            {% else %}                                                                                                  \
-                {% set author = commit.signature %}                                                                     \
-            {% endif %}                                                                                                 \
-            {% set commit_link = repository_url ~ "/commit/" ~ commit.id %}                                             \
-            {% set shorthand = commit.id | truncate(length=7, end="") %}                                                \
-            - **({{ scope }})** {{ commit.summary }} - ([{{shorthand}}]({{ commit_link }})) - {{ author }}
-        {% endfor %}                                                                                                    \
-    {% endfor %}                                                                                                        \
-    {% for commit in typed_commits | unscoped %}                                                                        \
-        {% if commit.author and repository_url %}                                                                       \
-            {% set author = "@" ~ commit.author %}                                                                      \
-            {% set author_link = platform ~ "/" ~ commit.author %}                                                      \
-            {% set author = "[" ~ author ~ "](" ~ author_link ~ ")" %}                                                  \
-        {% else %}                                                                                                      \
-            {% set author = commit.signature %}                                                                         \
-        {% endif %}                                                                                                     \
-        {% set commit_link = repository_url ~ "/commit/" ~ commit.id %}                                                 \
-        {% set shorthand = commit.id | truncate(length=7, end="") %}                                                    \
-        - {{ commit.summary }} - ([{{shorthand}}]({{ commit_link }})) - {{ author }}
-    {% endfor %}                                                                                                        \
-{% endfor %}                                                                                                            \
+{% for scope, scoped_commits in typed_commits | group_by(attribute="scope") -%}
+
+{% for commit in scoped_commits | sort(attribute="scope") -%}
+    {% if commit.author and repository_url -%}
+        {% set author = "@" ~ commit.author -%}
+        {% set author_link = platform ~ "/" ~ commit.author -%}
+        {% set author = "[" ~ author ~ "](" ~ author_link ~ ")" -%}
+    {% else -%}
+        {% set author = commit.signature -%}
+    {% endif -%}
+    {% set commit_link = repository_url ~ "/commit/" ~ commit.id -%}
+    {% set shorthand = commit.id | truncate(length=7, end="") -%}
+    - **({{ scope }})** {{ commit.summary }} - ([{{shorthand}}]({{ commit_link }})) - {{ author }}
+{% endfor -%}
+
+{% endfor -%}
+
+{% for commit in typed_commits | unscoped -%}
+    {% if commit.author and repository_url -%}
+        {% set author = "@" ~ commit.author -%}
+        {% set author_link = platform ~ "/" ~ commit.author -%}
+        {% set author = "[" ~ author ~ "](" ~ author_link ~ ")" -%}
+    {% else -%}
+        {% set author = commit.signature -%}
+    {% endif -%}
+    {% set commit_link = repository_url ~ "/commit/" ~ commit.id -%}
+    {% set shorthand = commit.id | truncate(length=7, end="") -%}
+    - {{ commit.summary }} - ([{{shorthand}}]({{ commit_link }})) - {{ author }}
+{% endfor -%}
+
+{% endfor -%}

--- a/src/conventional/changelog/template/simple
+++ b/src/conventional/changelog/template/simple
@@ -1,34 +1,40 @@
-{% if version.tag %}                                                                                                    \
+{% if version.tag -%}
     ## {{ version.tag }} - {{ date | date(format="%Y-%m-%d") }}
-{% else %}                                                                                                              \
-    {% set from = commits | last %}                                                                                     \
-    {% set to = version.id%}                                                                                            \
-    {% set from_shorthand = from.id | truncate(length=7, end="") %}                                                     \
-    {% set to_shorthand = to | truncate(length=7, end="") %}                                                            \
+{% else -%}
+    {% set from = commits | last -%}
+    {% set to = version.id-%}
+    {% set from_shorthand = from.id | truncate(length=7, end="") -%}
+    {% set to_shorthand = to | truncate(length=7, end="") -%}
     ## Unreleased ({{ from_shorthand ~ ".." ~ to_shorthand }})
-{% endif %}                                                                                                             \
-                                                                                                                        \
-{% for type, typed_commits in commits | sort(attribute="type")| group_by(attribute="type")%}                            \
-                                                                                                                        \
+{% endif -%}
+
+{% for type, typed_commits in commits | sort(attribute="type")| group_by(attribute="type")-%}
 #### {{ type | upper_first }}
-    {% for scope, scoped_commits in typed_commits | group_by(attribute="scope") %}                                      \
-        {% for commit in scoped_commits | sort(attribute="scope") %}                                                    \
-            {% if commit.author %}                                                                                      \
-                {% set author = "*" ~ commit.author  ~ "*" %}                                                           \
-            {% else %}                                                                                                  \
-                {% set author = commit.signature %}                                                                     \
-            {% endif %}                                                                                                 \
-            {% set shorthand = commit.id | truncate(length=7, end="") %}                                                \
-            - **({{ scope }})** {{ commit.summary }} - ({{shorthand}}) - {{ author }}
-        {% endfor %}                                                                                                    \
-    {% endfor %}                                                                                                        \
-    {% for commit in typed_commits | unscoped %}                                                                        \
-        {% if commit.author %}                                                                                          \
-            {% set author = commit.author %}                                                                            \
-        {% else %}                                                                                                      \
-            {% set author = commit.signature %}                                                                         \
-        {% endif %}                                                                                                     \
-            {% set shorthand = commit.id | truncate(length=7, end="") %}                                                \
-        - {{ commit.summary }} - ({{ shorthand }}) - {{ author }}
-    {% endfor %}                                                                                                        \
-{% endfor %}                                                                                                            \
+{% for scope, scoped_commits in typed_commits | group_by(attribute="scope") -%}
+
+{% for commit in scoped_commits | sort(attribute="scope") -%}
+
+    {% if commit.author -%}
+        {% set author = "*" ~ commit.author  ~ "*" -%}
+    {% else -%}
+        {% set author = commit.signature -%}
+    {% endif -%}
+
+    {% set shorthand = commit.id | truncate(length=7, end="") -%}
+    - **({{ scope }})** {{ commit.summary }} - ({{shorthand}}) - {{ author }}
+{% endfor -%}
+
+{% endfor -%}
+
+{%- for commit in typed_commits | unscoped -%}
+    {% if commit.author -%}
+        {% set author = commit.author -%}
+    {% else -%}
+        {% set author = commit.signature -%}
+    {% endif -%}
+
+    {% set shorthand = commit.id | truncate(length=7, end="") -%}
+    - {{ commit.summary }} - ({{ shorthand }}) - {{ author }}
+{% endfor -%}
+
+{% endfor -%}

--- a/tests/cog_tests/changelog.rs
+++ b/tests/cog_tests/changelog.rs
@@ -78,6 +78,7 @@ fn get_changelog_range() -> Result<()> {
                 - remove test generated dir - (a6fba9c) - oknozor
                 #### Tests
                 - **(cli)** add verify it tests - (9da7321) - *oknozor*
+
                 ",
             today = today
         )
@@ -112,6 +113,7 @@ fn get_changelog_from_untagged_repo() -> Result<()> {
                     - bug fix - ({commit_three}) - Tom
                     #### Features
                     - **(taef)** feature - ({commit_two}) - Tom
+
                     ",
             commit_two = &commit_two[0..7],
             commit_three = &commit_three[0..7]
@@ -153,6 +155,7 @@ fn get_changelog_from_tagged_repo() -> Result<()> {
                     ## 1.0.0 - {today}
                     #### Features
                     - **(taef)** feature - ({commit_one}) - Tom
+
                     ",
             commit_one = &commit_one[0..7],
             commit_two = &commit_two[0..7],
@@ -193,6 +196,7 @@ fn get_changelog_at_tag() -> Result<()> {
                     #### Features
                     - **(taef)** feature - ({commit_one}) - Tom
                     - feature 2 - ({commit_two}) - Tom
+
                     ",
             today = today,
             commit_one = &commit_one[0..7],
@@ -243,6 +247,7 @@ fn get_changelog_with_tag_prefix() -> Result<()> {
                     ## v1.0.0 - {today}
                     #### Features
                     - feature 1 - ({commit_one}) - Tom
+
                     ",
             today = today,
             commit_one = &commit_one[0..7],
@@ -297,6 +302,7 @@ fn get_changelog_at_tag_prefix() -> Result<()> {
                     - feature 1 - ({commit_two}) - Tom
                     #### Miscellaneous Chores
                     - **(version)** v2.0.0 - ({commit_four}) - Tom
+
                     ",
             today = today,
             commit_two = &commit_two[0..7],
@@ -348,6 +354,7 @@ fn get_changelog_from_tag_to_tagged_head() -> Result<()> {
                 #### Features
                 - feature 1 - ({commit_two}) - Tom
                 - start - ({commit_one}) - Tom
+
                 ",
             today = today,
             commit_one = &commit_one[0..7],
@@ -419,6 +426,7 @@ fn get_changelog_whith_custom_template() -> Result<()> {
             #### Features
             -  feature 1 - ([{commit_two_short}](https://github.com/test/test/commit/{commit_two})) - Tom
             - **(scope1)** start - ([{commit_one_short}](https://github.com/test/test/commit/{commit_one})) - Tom
+
             ",
             today = today,
             init_commit = &init_commit,

--- a/tests/cog_tests/template.md
+++ b/tests/cog_tests/template.md
@@ -1,34 +1,35 @@
-{% if version.tag and from.tag %}                                                                                               \
+{% if version.tag and from.tag -%}                                                                                               
 ## [{{ version.tag }}]({{repository_url ~ "/compare/" ~ from.tag ~ ".." ~ version.tag}}) - {{ date | date(format="%Y-%m-%d") }}
-{% elif version.tag and from.id %}                                                                                              \
+{% elif version.tag and from.id -%}                                                                                              
 ## [{{ version.tag }}]({{repository_url ~ "/compare/" ~ from.id ~ ".." ~ version.tag}}) - {{ date | date(format="%Y-%m-%d") }}
-{% else %}                                                                                                                      \
-                                                                                                                                \
-{% set from = from.id %}                                                                                                        \
-{% set to = version.id %}                                                                                                       \
-{% set from_shorthand = from.id | truncate(length=7, end="") %}                                                                 \
-{% set to_shorthand = version.id | truncate(length=7, end="") %}                                                                \
+{% else -%}                                                                                                                      
+                                                                                                                                
+{% set from = from.id -%}                                                                                                        
+{% set to = version.id -%}                                                                                                       
+{% set from_shorthand = from.id | truncate(length=7, end="") -%}                                                                 
+{% set to_shorthand = version.id | truncate(length=7, end="") -%}                                                                
 ## Unreleased ([{{ from_shorthand ~ ".." ~ to_shorthand }}]({{repository_url ~ "/compare/" ~ from_shorthand ~ ".." ~ to_shorthand}}))
-{% endif %}                                                                                                                     \
-{% for type, typed_commits in commits | sort(attribute="type")| group_by(attribute="type")%}                                    \
+{% endif -%}                                                                                                                     
+{% for type, typed_commits in commits | sort(attribute="type")| group_by(attribute="type")-%}                                    
 #### {{ type | upper_first }}
-    {% for commit in typed_commits %}                                                                                           \
-        {% if commit.author and repository_url %}                                                                                \
-        {% set author = "@" ~ commit.author %}                                                                                   \
-        {% set author_link = platform ~ "/" ~ commit.author %}                                                                   \
-        {% set author = "[" ~ author ~ "](" ~ author_link ~ ")" %}                                                               \
-        {% else %}                                                                                                               \
-        {% set author = commit.signature %}                                                                                      \
-        {% endif %}                                                                                                              \
-                                                                                                                                    \
-        {% if commit.scope %}                                                                                                    \
-        {% set scope = "**(" ~ commit.scope ~ ")**" %}                                                                             \
-        {% else %}                                                                                                                 \
-        {% set scope = "" %}                                                                                                       \
-        {% endif %}                                                                                                               \
-        \
-        {% set commit_link = repository_url ~ "/commit/" ~ commit.id %}                                                           \
-{% set shorthand = commit.id | truncate(length=7, end="") %}                                                                     \
-- {{ scope }} {{ commit.summary }} - ([{{shorthand}}]({{ commit_link }})) - {{ author }}
-    {% endfor %}                                                                                                                \
-{% endfor %}                                                                                                                    \
+{% for commit in typed_commits -%}                                                                                           
+    {% if commit.author and repository_url -%}                                                                                
+    {% set author = "@" ~ commit.author -%}                                                                                   
+    {% set author_link = platform ~ "/" ~ commit.author -%}                                                                   
+    {% set author = "[" ~ author ~ "](" ~ author_link ~ ")" -%}                                                               
+    {% else -%}                                                                                                               
+    {% set author = commit.signature -%}                                                                                      
+    {% endif -%}                                                                                                              
+                                                                                                                                
+    {% if commit.scope -%}                                                                                                    
+    {% set scope = "**(" ~ commit.scope ~ ")**" -%}                                                                             
+    {% else -%}                                                                                                                 
+    {% set scope = "" -%}                                                                                                       
+    {% endif -%}                                                                                                               
+    
+    {% set commit_link = repository_url ~ "/commit/" ~ commit.id -%}                                                           
+    {% set shorthand = commit.id | truncate(length=7, end="") -%}                                                                     
+    - {{ scope }} {{ commit.summary }} - ([{{shorthand}}]({{ commit_link }})) - {{ author }}
+{% endfor -%}                                                                                                                
+
+{% endfor -%}                                                                                                                    


### PR DESCRIPTION
This PR removes the anoying antislashes from changelog templates. 
While it makes the templates overall more readable and easier to write, the `-%}` is prone to error so we need to be extra careful with indentation while writing or updating templates.  
Documentation should also be updated accordingly.