### PR TITLE
Add dry-run option for bump command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,6 +252,7 @@ dependencies = [
  "indoc",
  "itertools",
  "lazy_static",
+ "log",
  "pest",
  "pest_derive",
  "predicates 1.0.8",
@@ -262,6 +263,7 @@ dependencies = [
  "serde",
  "shell-words",
  "speculoos",
+ "stderrlog",
  "tempfile",
  "tera",
  "toml",
@@ -649,9 +651,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
+checksum = "6389c490849ff5bc16be905ae24bc913a9c8892e19b2341dbc175e14c341c2b8"
 dependencies = [
  "cfg-if",
 ]
@@ -774,12 +776,6 @@ checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
  "autocfg",
 ]
-
-[[package]]
-name = "once_cell"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
 
 [[package]]
 name = "opaque-debug"
@@ -1323,6 +1319,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "stderrlog"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45a53e2eff3e94a019afa6265e8ee04cb05b9d33fe9f5078b14e4e391d155a38"
+dependencies = [
+ "atty",
+ "chrono",
+ "log",
+ "termcolor",
+ "thread_local",
+]
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1398,11 +1407,11 @@ checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
 
 [[package]]
 name = "thread_local"
-version = "1.1.4"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
+checksum = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
 dependencies = [
- "once_cell",
+ "lazy_static",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,8 @@ pest = "2.1.3"
 pest_derive = "2.1.0"
 tera = "1.15.0"
 globset = "0.4.8"
+log = "0.4.16"
+stderrlog = "0.5.1"
 
 [dev-dependencies]
 assert_cmd = "1.0.3"

--- a/src/bin/cog.rs
+++ b/src/bin/cog.rs
@@ -143,6 +143,10 @@ enum Cli {
         /// Specify the bump profile hooks to run
         #[clap(short = 'H', long, possible_values = hook_profiles())]
         hook_profile: Option<String>,
+
+        /// Dry-run : get the target version. No action taken
+        #[clap(short, long)]
+        dry_run: bool,
     },
 
     /// Install cog config files
@@ -200,6 +204,7 @@ fn main() -> Result<()> {
             patch,
             pre,
             hook_profile,
+            dry_run,
         } => {
             let mut cocogitto = CocoGitto::get()?;
 
@@ -212,7 +217,7 @@ fn main() -> Result<()> {
                 _ => unreachable!(),
             };
 
-            cocogitto.create_version(increment, pre.as_deref(), hook_profile.as_deref())?
+            cocogitto.create_version(increment, pre.as_deref(), hook_profile.as_deref(), dry_run)?
         }
         Cli::Verify {
             message,

--- a/src/conventional/changelog/release.rs
+++ b/src/conventional/changelog/release.rs
@@ -7,6 +7,7 @@ use crate::git::oid::OidOf;
 use crate::git::revspec::CommitRange;
 use crate::settings;
 use colored::Colorize;
+use log::warn;
 
 #[derive(Debug, Serialize)]
 pub struct Release<'a> {
@@ -33,7 +34,7 @@ impl<'a> From<CommitRange<'a>> for Release<'a> {
                 Ok(commit) => commits.push(ChangelogCommit::from(commit)),
                 Err(err) => {
                     let err = err.to_string().red();
-                    eprintln!("{}", err);
+                    warn!("{}", err);
                 }
             };
         }

--- a/src/conventional/commit.rs
+++ b/src/conventional/commit.rs
@@ -7,6 +7,7 @@ use chrono::{NaiveDateTime, Utc};
 use colored::*;
 use conventional_commit_parser::commit::ConventionalCommit;
 use git2::Commit as Git2Commit;
+use log::info;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Eq, PartialEq)]
@@ -65,7 +66,6 @@ impl Commit {
             Err(cause) => {
                 let message = git2_message.trim_end();
                 let summary = Commit::short_summary_from_str(message);
-
                 Err(ConventionalCommitError::CommitFormat {
                     oid,
                     summary,
@@ -199,7 +199,7 @@ pub fn verify(
     let msg = msg.trim();
 
     if msg.starts_with("Merge ") && ignore_merge_commit {
-        println!("{}", "Merge commit was ignored".yellow());
+        info!("{}", "Merge commit was ignored".yellow());
         return Ok(());
     }
 
@@ -208,7 +208,7 @@ pub fn verify(
     match commit {
         Ok(commit) => match &SETTINGS.commit_types().get(&commit.commit_type) {
             Some(_) => {
-                println!(
+                info!(
                     "{}",
                     Commit {
                         oid: "not committed".to_string(),

--- a/src/conventional/version.rs
+++ b/src/conventional/version.rs
@@ -7,6 +7,7 @@ use colored::*;
 use conventional_commit_parser::commit::CommitType;
 use git2::Commit as Git2Commit;
 use itertools::Itertools;
+use log::info;
 use semver::Version;
 
 #[derive(Debug, PartialEq)]
@@ -148,7 +149,7 @@ impl VersionIncrement {
             skip_message.push_str(&format!("\t- {}: {}\n", commit_type.as_ref(), count))
         }
 
-        println!("{}", skip_message);
+        info!("{}", skip_message);
 
         let bump_commits = conventional_commits
             .iter()
@@ -163,7 +164,7 @@ impl VersionIncrement {
         for commit in bump_commits {
             match commit {
                 Ok(commit) if commit.message.is_breaking_change => {
-                    println!(
+                    info!(
                         "Found {} commit {} with type: {}",
                         "BREAKING CHANGE".red(),
                         commit.shorthand().blue(),
@@ -171,10 +172,10 @@ impl VersionIncrement {
                     )
                 }
                 Ok(commit) if commit.message.commit_type == CommitType::BugFix => {
-                    println!("Found bug fix commit {}", commit.shorthand().blue())
+                    info!("Found bug fix commit {}", commit.shorthand().blue())
                 }
                 Ok(commit) if commit.message.commit_type == CommitType::Feature => {
-                    println!("Found feature commit {}", commit.shorthand().blue())
+                    info!("Found feature commit {}", commit.shorthand().blue())
                 }
                 _ => (),
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -475,7 +475,7 @@ impl CocoGitto {
         };
 
         if dry_run {
-            println!("{}", version_str);
+            print!("{}", version_str);
             return Ok(());
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -406,6 +406,7 @@ impl CocoGitto {
         increment: VersionIncrement,
         pre_release: Option<&str>,
         hooks_config: Option<&str>,
+        dry_run: bool,
     ) -> Result<()> {
         if *SETTINGS == Settings::default() {
             let part1 = "Warning: using".yellow();
@@ -472,6 +473,11 @@ impl CocoGitto {
             None => next_version.to_string(),
             Some(prefix) => format!("{}{}", prefix, next_version),
         };
+
+        if dry_run {
+            println!("{}", version_str);
+            return Ok(());
+        }
 
         let origin = if current_version == Version::new(0, 0, 0) {
             self.repository.get_first_commit()?.to_string()

--- a/tests/cog_tests/bump.rs
+++ b/tests/cog_tests/bump.rs
@@ -50,6 +50,30 @@ fn auto_bump_minor_from_latest_tag() -> Result<()> {
 }
 
 #[sealed_test]
+fn auto_bump_dry_run_from_latest_tag() -> Result<()> {
+    git_init()?;
+    git_commit("chore: init")?;
+    git_commit("feat(taef): feature")?;
+    git_commit("fix: bug fix")?;
+    git_tag("1.0.0")?;
+    git_commit("feat(taef): feature")?;
+    git_commit("feat: feature 1")?;
+    git_commit("feat: feature 2")?;
+
+    Command::cargo_bin("cog")?
+        .arg("bump")
+        .arg("--auto")
+        .arg("--dry-run")
+        .assert()
+        .success()
+        .stdout("1.1.0");
+
+    assert_that!(Path::new("CHANGELOG.md")).does_not_exist();
+    assert_tag_does_not_exist("1.1.0")?;
+    Ok(())
+}
+
+#[sealed_test]
 fn auto_bump_major_from_latest_tag() -> Result<()> {
     git_init()?;
     git_commit("chore: init")?;

--- a/tests/cog_tests/bump.rs
+++ b/tests/cog_tests/bump.rs
@@ -278,12 +278,12 @@ fn bump_with_profile_hook() -> Result<()> {
     git_tag("1.0.0")?;
     git_commit("feat: feature")?;
 
-    let expected = indoc!(
+    let expected_stdout = indoc!(
         "current 1.0.0
             next 1.0.1
-            Bumped version: 1.0.0 -> 1.0.1
         "
     );
+    let expected_stderr = "Bumped version: 1.0.0 -> 1.0.1\n";
 
     // Act
     Command::cargo_bin("cog")?
@@ -294,7 +294,8 @@ fn bump_with_profile_hook() -> Result<()> {
         .unwrap()
         // Assert
         .assert()
-        .stdout(expected)
+        .stdout(expected_stdout)
+        .stderr(expected_stderr)
         .success();
 
     assert_tag_exists("1.0.1")?;

--- a/tests/cog_tests/check.rs
+++ b/tests/cog_tests/check.rs
@@ -19,7 +19,7 @@ fn cog_check_ok() -> Result<()> {
         // Assert
         .assert()
         .success()
-        .stdout(predicate::str::contains("No errored commits"));
+        .stderr(predicate::str::contains("No errored commits"));
     Ok(())
 }
 
@@ -58,7 +58,7 @@ fn cog_check_from_latest_tag_ok() -> Result<()> {
         // Assert
         .assert()
         .success()
-        .stdout(predicate::str::contains("No errored commits"));
+        .stderr(predicate::str::contains("No errored commits"));
     Ok(())
 }
 

--- a/tests/cog_tests/init.rs
+++ b/tests/cog_tests/init.rs
@@ -53,7 +53,7 @@ fn fail_if_config_exist() -> Result<()> {
         .arg("test_repo_existing")
         // Assert
         .assert()
-        .stdout("Found git repository in \"test_repo_existing\", skipping initialisation\n")
+        .stderr("Found git repository in \"test_repo_existing\", skipping initialisation\n")
         .success();
 
     assert_that!(PathBuf::from("cog.toml")).exists();

--- a/tests/cog_tests/verify.rs
+++ b/tests/cog_tests/verify.rs
@@ -29,7 +29,7 @@ fn verify_ok() -> Result<()> {
         // Assert
         .assert()
         .success()
-        .stdout(expected);
+        .stderr(expected);
 
     Ok(())
 }
@@ -55,7 +55,7 @@ fn verify_with_scope() -> Result<()> {
         // Assert
         .assert()
         .success()
-        .stdout(expected);
+        .stderr(expected);
     Ok(())
 }
 

--- a/tests/helpers.rs
+++ b/tests/helpers.rs
@@ -81,6 +81,13 @@ pub fn assert_tag_exists(tag: &str) -> Result<()> {
     Ok(())
 }
 
+pub fn assert_tag_does_not_exist(tag: &str) -> Result<()> {
+    let tags = run_fun!(git --no-pager tag)?;
+    let tags: Vec<&str> = tags.split('\n').collect();
+    assert_that!(tags).does_not_contain(&tag);
+    Ok(())
+}
+
 pub fn assert_latest_tag(tag: &str) -> Result<()> {
     let tags = run_fun!(git --no-pager tag)?;
     let tags: Vec<&str> = tags.split('\n').collect();

--- a/tests/helpers.rs
+++ b/tests/helpers.rs
@@ -51,7 +51,7 @@ where
 {
     let path = path.to_string();
     run_cmd!(
-        info writing $content to $path;
+        echo "writing $content to $path";
         echo $content > $path;
         git add $path;
     )

--- a/tests/lib_tests/bump.rs
+++ b/tests/lib_tests/bump.rs
@@ -20,7 +20,7 @@ fn bump_ok() -> Result<()> {
     let mut cocogitto = CocoGitto::get()?;
 
     // Act
-    let result = cocogitto.create_version(VersionIncrement::Auto, None, None);
+    let result = cocogitto.create_version(VersionIncrement::Auto, None, None, false);
 
     // Assert
     assert_that!(result).is_ok();
@@ -38,7 +38,7 @@ fn should_fallback_to_0_0_0_when_there_is_no_tag() -> Result<()> {
     let mut cocogitto = CocoGitto::get()?;
 
     // Act
-    let result = cocogitto.create_version(VersionIncrement::Auto, None, None);
+    let result = cocogitto.create_version(VersionIncrement::Auto, None, None, false);
 
     // Assert
     assert_that!(result).is_ok();
@@ -58,7 +58,7 @@ fn should_fail_when_latest_tag_is_not_semver_compliant() -> Result<()> {
     let mut cocogitto = CocoGitto::get()?;
 
     // Act
-    let result = cocogitto.create_version(VersionIncrement::Auto, None, None);
+    let result = cocogitto.create_version(VersionIncrement::Auto, None, None, false);
     let error = result.unwrap_err().to_string();
     let error = error.as_str();
 
@@ -89,7 +89,7 @@ fn bump_with_whitelisted_branch_ok() -> Result<()> {
     let mut cocogitto = CocoGitto::get()?;
 
     // Act
-    let result = cocogitto.create_version(VersionIncrement::Auto, None, None);
+    let result = cocogitto.create_version(VersionIncrement::Auto, None, None, false);
 
     // Assert
     assert_that!(result).is_ok();
@@ -114,7 +114,7 @@ fn bump_with_whitelisted_branch_fails() -> Result<()> {
     let mut cocogitto = CocoGitto::get()?;
 
     // Act
-    let result = cocogitto.create_version(VersionIncrement::Auto, None, None);
+    let result = cocogitto.create_version(VersionIncrement::Auto, None, None, false);
 
     // Assert
     assert_that!(result.unwrap_err().to_string()).is_equal_to(
@@ -143,7 +143,7 @@ fn bump_with_whitelisted_branch_pattern_ok() -> Result<()> {
     let mut cocogitto = CocoGitto::get()?;
 
     // Act
-    let result = cocogitto.create_version(VersionIncrement::Auto, None, None);
+    let result = cocogitto.create_version(VersionIncrement::Auto, None, None, false);
 
     // Assert
     assert_that!(result).is_ok();
@@ -168,7 +168,7 @@ fn bump_with_whitelisted_branch_pattern_err() -> Result<()> {
     let mut cocogitto = CocoGitto::get()?;
 
     // Act
-    let result = cocogitto.create_version(VersionIncrement::Auto, None, None);
+    let result = cocogitto.create_version(VersionIncrement::Auto, None, None, false);
 
     // Assert
     assert_that!(result).is_err();

--- a/tests/lib_tests/init.rs
+++ b/tests/lib_tests/init.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 use crate::helpers::*;
 
 use anyhow::Result;
+use cmd_lib::run_cmd;
 use sealed_test::prelude::*;
 use speculoos::prelude::*;
 
@@ -30,6 +31,6 @@ fn should_skip_initialization_if_repository_exists() -> Result<()> {
     // Assert
     assert_that!(Path::new("cog.toml")).exists();
     assert_that!(git_log_head()?).is_equal_to("The first commit\n".to_string());
-    assert_that!(git_status()?).contains("new file:   cog.toml");
+    assert_that!(git_status()?).contains("git restore --staged");
     Ok(())
 }


### PR DESCRIPTION
Add a `dry-run` option for bump command.  
On a `cog bump -a -d`, the target version will be returned.  
In order to get only the version on stdout, other text outputs are diverted to stderr, using stderrlog. The default log level is INFO (no logs positionned to debug), meaning that all the outputs are still displayed by default, without any extra info (log level, timestamp, etc…) to preserve the current behaviour.  
The v flag has been reaffected to log leverl (-v for ERROR, -vv for WARNING, -vvv for INFO, …), but I don’t know if it’s needed / relevant.
