### PR TITLE
feat(cli): generate man pages with clap-mangen

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -46,4 +46,5 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           body_path: GITHUB_CHANGELOG.md
+          files: cocogitto_man_pages/**
           tag_name: ${{ steps.release.outputs.version }}

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .idea
 .vscode
 issues
+cocogitto_man_pages

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,6 +209,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_mangen"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0649fb4156bbd7306896025005596033879a2051f9a3aa7416ab915df1f8fdac"
+dependencies = [
+ "clap",
+ "roff",
+]
+
+[[package]]
 name = "cmd_lib"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -242,6 +252,7 @@ dependencies = [
  "chrono",
  "clap",
  "clap_complete",
+ "clap_mangen",
  "cmd_lib",
  "colored",
  "config",
@@ -1184,6 +1195,12 @@ checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "roff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b833d8d034ea094b1ea68aa6d5c740e0d04bad9d16568d08ba6f76823a114316"
 
 [[package]]
 name = "rustc-serialize"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ lazy_static = "^1"
 toml = "^0"
 clap = { version = "3.1", optional = true, features = ["derive"] }
 clap_complete = { version = "3.0", optional = true }
+clap_mangen = { version = "0.1", optional = true }
 conventional_commit_parser = "0.9.4"
 pest = "2.1.3"
 pest_derive = "2.1.0"
@@ -58,6 +59,7 @@ cmd_lib = "1.3.0"
 [features]
 default = ["cli"]
 cli = ["clap", "clap_complete"]
+man_gen = ["clap", "clap_complete", "clap_mangen"]
 
 [lib]
 name = "cocogitto"
@@ -67,6 +69,11 @@ path = "src/lib.rs"
 name = "cog"
 path = "src/bin/cog.rs"
 required-features = ["clap", "clap_complete"]
+
+[[bin]]
+name = "cog_man_gen"
+path = "src/bin/man_gen.rs"
+required-features = ["clap", "clap_complete", "clap_mangen"]
 
 [[test]]
 name = "all"

--- a/cog.toml
+++ b/cog.toml
@@ -9,7 +9,7 @@ pre_bump_hooks = [
     "cargo clippy",
     "cargo fmt --all",
     "cargo set-version {{version}}",
-    "cargo build --release",
+    "cargo build --release --all-features",
 ]
 
 # A list of command to run AFTER creating a version.

--- a/src/bin/cog.rs
+++ b/src/bin/cog.rs
@@ -1,7 +1,5 @@
 mod cog_commit;
 
-use std::path::PathBuf;
-
 use cocogitto::conventional::changelog::template::{RemoteContext, Template};
 use cocogitto::conventional::commit;
 use cocogitto::conventional::version::VersionIncrement;
@@ -12,199 +10,8 @@ use cocogitto::log::output::Output;
 use cocogitto::{CocoGitto, SETTINGS};
 
 use anyhow::{Context, Result};
-use clap::{AppSettings, ArgGroup, Args, CommandFactory, Parser, Subcommand};
-use clap_complete::Shell;
-
-fn hook_profiles() -> Vec<&'static str> {
-    SETTINGS
-        .bump_profiles
-        .keys()
-        .map(|profile| profile.as_ref())
-        .collect()
-}
-
-/// A command line tool for the conventional commits and semver specifications
-#[derive(Parser)]
-#[clap(global_setting = AppSettings::DeriveDisplayOrder)]
-#[clap(
-    version,
-    name = "Cog",
-    author = "Paul D. <paul.delafosse@protonmail.com>"
-)]
-struct Cli {
-    /// The level of verbosity: -v for ERROR, -vv for WARNING, -vvv for INFO
-    #[clap(long, short = 'v', parse(from_occurrences))]
-    verbose: i8,
-
-    /// Silence all output, no matter the value of verbosity
-    #[clap(long, short = 'q')]
-    quiet: bool,
-
-    #[clap(subcommand)]
-    command: Command,
-}
-
-#[derive(Subcommand)]
-enum Command {
-    /// Verify all commit messages against the conventional commit specification
-    Check {
-        /// Check commit history, starting from the latest tag to HEAD
-        #[clap(short = 'l', long)]
-        from_latest_tag: bool,
-        /// Ignore merge commits messages
-        #[clap(short, long)]
-        ignore_merge_commits: bool,
-    },
-
-    /// Create a new conventional commit
-    Commit(CommitArgs),
-
-    /// Interactively rename invalid commit messages
-    Edit {
-        /// Edit non conventional commits, starting from the latest tag to HEAD
-        #[clap(short = 'l', long)]
-        from_latest_tag: bool,
-    },
-
-    /// Like git log but for conventional commits
-    Log {
-        /// filter BREAKING CHANGE commits
-        #[clap(short = 'B', long)]
-        breaking_change: bool,
-
-        /// filter on commit type
-        #[clap(short, long = "type", value_name = "type")]
-        typ: Option<Vec<String>>,
-
-        /// filter on commit author
-        #[clap(short, long)]
-        author: Option<Vec<String>>,
-
-        /// filter on commit scope
-        #[clap(short, long)]
-        scope: Option<Vec<String>>,
-
-        /// omit error on the commit log
-        #[clap(short = 'e', long)]
-        no_error: bool,
-    },
-
-    /// Verify a single commit message
-    Verify {
-        /// The commit message
-        message: String,
-        /// Ignore merge commits messages
-        #[clap(short, long)]
-        ignore_merge_commits: bool,
-    },
-
-    /// Display a changelog for the given commit oid range
-    Changelog {
-        /// Generate the changelog from in the given spec range
-        #[clap(conflicts_with = "at")]
-        pattern: Option<String>,
-
-        /// Generate the changelog for a specific git tag
-        #[clap(short, long)]
-        at: Option<String>,
-
-        /// Generate the changelog with the given template.
-        /// Possible values are 'remote', 'full_hash', 'default' or the path to your template.  
-        /// If not specified cog will use cog.toml template config or fallback to 'default'.
-        #[clap(name = "template", long, short)]
-        template: Option<String>,
-
-        /// Url to use during template generation
-        #[clap(name = "remote", long, short, requires_all(&["owner", "repository"]))]
-        remote: Option<String>,
-
-        /// Repository owner to use during template generation
-        #[clap(name = "owner", long, short, requires_all(& ["remote", "repository"]))]
-        owner: Option<String>,
-
-        /// Name of the repository used during template generation
-        #[clap(name = "repository", long, requires_all(& ["owner", "remote"]))]
-        repository: Option<String>,
-    },
-
-    /// Commit changelog from latest tag to HEAD and create new tag
-    #[clap(group = ArgGroup::new("bump-spec").required(true))]
-    Bump {
-        /// Manually set the target version
-        #[clap(long, group = "bump-spec")]
-        version: Option<String>,
-
-        /// Automatically suggest the target version
-        #[clap(short, long, group = "bump-spec")]
-        auto: bool,
-
-        /// Increment the major version
-        #[clap(short = 'M', long, group = "bump-spec")]
-        major: bool,
-
-        /// Increment the minor version
-        #[clap(short, long, group = "bump-spec")]
-        minor: bool,
-
-        /// Increment the patch version
-        #[clap(short, long, group = "bump-spec")]
-        patch: bool,
-
-        /// Set the pre-release version
-        #[clap(long)]
-        pre: Option<String>,
-
-        /// Specify the bump profile hooks to run
-        #[clap(short = 'H', long, possible_values = hook_profiles())]
-        hook_profile: Option<String>,
-
-        /// Dry-run : get the target version. No action taken
-        #[clap(short, long)]
-        dry_run: bool,
-    },
-
-    /// Install cog config files
-    Init {
-        /// path to init
-        #[clap(default_value = ".")]
-        path: PathBuf,
-    },
-
-    /// Add git hooks to the repository
-    InstallHook {
-        /// Type of hook to install
-        #[clap(possible_values = &["commit-msg", "pre-push", "all"])]
-        hook_type: String,
-    },
-
-    /// Generate shell completions
-    GenerateCompletions {
-        /// Type of completions to generate
-        #[clap(name = "type", arg_enum)]
-        shell: Shell,
-    },
-}
-
-#[derive(Args)]
-struct CommitArgs {
-    /// Conventional commit type
-    #[clap(name = "type", value_name = "TYPE", possible_values = cog_commit::commit_types())]
-    typ: String,
-
-    /// Commit description
-    message: String,
-
-    /// Conventional commit scope
-    scope: Option<String>,
-
-    /// Create a BREAKING CHANGE commit
-    #[clap(short = 'B', long)]
-    breaking_change: bool,
-
-    /// Open commit message in an editor
-    #[clap(short, long)]
-    edit: bool,
-}
+use clap::{CommandFactory, Parser};
+use cocogitto::cli::{Cli, CogCommand, CommitArgs};
 
 fn main() -> Result<()> {
     let cli = Cli::parse();
@@ -212,7 +19,7 @@ fn main() -> Result<()> {
     init_logs(cli.verbose, cli.quiet);
 
     match cli.command {
-        Command::Bump {
+        CogCommand::Bump {
             version,
             auto,
             major,
@@ -235,7 +42,7 @@ fn main() -> Result<()> {
 
             cocogitto.create_version(increment, pre.as_deref(), hook_profile.as_deref(), dry_run)?
         }
-        Command::Verify {
+        CogCommand::Verify {
             message,
             ignore_merge_commits,
         } => {
@@ -246,7 +53,7 @@ fn main() -> Result<()> {
 
             commit::verify(author, &message, ignore_merge_commits)?;
         }
-        Command::Check {
+        CogCommand::Check {
             from_latest_tag,
             ignore_merge_commits,
         } => {
@@ -254,11 +61,11 @@ fn main() -> Result<()> {
             let ignore_merge_commits = ignore_merge_commits || SETTINGS.ignore_merge_commits;
             cocogitto.check(from_latest_tag, ignore_merge_commits)?;
         }
-        Command::Edit { from_latest_tag } => {
+        CogCommand::Edit { from_latest_tag } => {
             let cocogitto = CocoGitto::get()?;
             cocogitto.check_and_edit(from_latest_tag)?;
         }
-        Command::Log {
+        CogCommand::Log {
             breaking_change,
             typ,
             author,
@@ -308,7 +115,7 @@ fn main() -> Result<()> {
                 .write_all(content.as_bytes())
                 .context("failed to write log into the pager")?;
         }
-        Command::Changelog {
+        CogCommand::Changelog {
             pattern,
             at,
             template,
@@ -338,10 +145,10 @@ fn main() -> Result<()> {
             };
             println!("{}", result);
         }
-        Command::Init { path } => {
+        CogCommand::Init { path } => {
             cocogitto::init(&path)?;
         }
-        Command::InstallHook { hook_type } => {
+        CogCommand::InstallHook { hook_type } => {
             let cocogitto = CocoGitto::get()?;
             match hook_type.as_str() {
                 "commit-msg" => cocogitto.install_hook(HookKind::PrepareCommit)?,
@@ -350,10 +157,10 @@ fn main() -> Result<()> {
                 _ => unreachable!(),
             }
         }
-        Command::GenerateCompletions { shell } => {
+        CogCommand::GenerateCompletions { shell } => {
             clap_complete::generate(shell, &mut Cli::command(), "cog", &mut std::io::stdout());
         }
-        Command::Commit(CommitArgs {
+        CogCommand::Commit(CommitArgs {
             typ,
             message,
             scope,

--- a/src/bin/cog_commit.rs
+++ b/src/bin/cog_commit.rs
@@ -1,17 +1,8 @@
 use std::fmt::Write;
 
-use cocogitto::COMMITS_METADATA;
-
 use anyhow::{bail, Result};
 use conventional_commit_parser::commit::Separator;
 use itertools::Itertools;
-
-pub fn commit_types() -> Vec<&'static str> {
-    COMMITS_METADATA
-        .iter()
-        .map(|(commit_type, _)| commit_type.as_ref())
-        .collect()
-}
 
 pub fn edit_message(
     typ: &str,

--- a/src/bin/man_gen.rs
+++ b/src/bin/man_gen.rs
@@ -1,0 +1,35 @@
+use clap::CommandFactory;
+use std::fs;
+use std::path::PathBuf;
+
+fn main() -> std::io::Result<()> {
+    let man_pages_dir = &PathBuf::from("cocogitto_man_pages");
+
+    if man_pages_dir.exists() {
+        fs::remove_dir_all(man_pages_dir)?;
+    }
+
+    fs::create_dir(man_pages_dir)?;
+
+    let mut command = cocogitto::cli::Cli::command();
+    let cmd_name = command.get_name().to_string();
+
+    for subcommand in command.get_subcommands_mut() {
+        let name = subcommand.get_name().clone();
+        let name = format!("{}-{}", cmd_name, name);
+        let sub = subcommand.clone().name(&name);
+        let man = clap_mangen::Man::new(sub);
+        let mut buffer: Vec<u8> = Default::default();
+        man.render(&mut buffer)?;
+        std::fs::write(man_pages_dir.join(&format!("{}.1", name)), buffer)?;
+    }
+
+    let man = clap_mangen::Man::new(command);
+
+    let mut buffer: Vec<u8> = Default::default();
+    man.render(&mut buffer)?;
+
+    std::fs::write(man_pages_dir.join(&format!("{}.1", cmd_name)), buffer)?;
+
+    Ok(())
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,202 @@
+use crate::{COMMITS_METADATA, SETTINGS};
+use clap::{AppSettings, ArgGroup, Args, Parser, Subcommand};
+use clap_complete::Shell;
+use std::path::PathBuf;
+
+/// A command line tool for the conventional commits and semver specifications
+#[derive(Parser)]
+#[clap(global_setting = AppSettings::DeriveDisplayOrder)]
+#[clap(
+    version,
+    name = "cog",
+    author = "Paul D. <paul.delafosse@protonmail.com>"
+)]
+pub struct Cli {
+    /// The level of verbosity: -v for ERROR, -vv for WARNING, -vvv for INFO
+    #[clap(long, short = 'v', parse(from_occurrences))]
+    pub verbose: i8,
+
+    /// Silence all output, no matter the value of verbosity
+    #[clap(long, short = 'q')]
+    pub quiet: bool,
+
+    #[clap(subcommand)]
+    pub command: CogCommand,
+}
+
+#[derive(Subcommand)]
+pub enum CogCommand {
+    /// Verify all commit messages against the conventional commit specification
+    Check {
+        /// Check commit history, starting from the latest tag to HEAD
+        #[clap(short = 'l', long)]
+        from_latest_tag: bool,
+        /// Ignore merge commits messages
+        #[clap(short, long)]
+        ignore_merge_commits: bool,
+    },
+
+    /// Create a new conventional commit
+    Commit(CommitArgs),
+
+    /// Interactively rename invalid commit messages
+    Edit {
+        /// Edit non conventional commits, starting from the latest tag to HEAD
+        #[clap(short = 'l', long)]
+        from_latest_tag: bool,
+    },
+
+    /// Like git log but for conventional commits
+    Log {
+        /// filter BREAKING CHANGE commits
+        #[clap(short = 'B', long)]
+        breaking_change: bool,
+
+        /// filter on commit type
+        #[clap(short, long = "type", value_name = "type")]
+        typ: Option<Vec<String>>,
+
+        /// filter on commit author
+        #[clap(short, long)]
+        author: Option<Vec<String>>,
+
+        /// filter on commit scope
+        #[clap(short, long)]
+        scope: Option<Vec<String>>,
+
+        /// omit error on the commit log
+        #[clap(short = 'e', long)]
+        no_error: bool,
+    },
+
+    /// Verify a single commit message
+    Verify {
+        /// The commit message
+        message: String,
+        /// Ignore merge commits messages
+        #[clap(short, long)]
+        ignore_merge_commits: bool,
+    },
+
+    /// Display a changelog for the given commit oid range
+    Changelog {
+        /// Generate the changelog from in the given spec range
+        #[clap(conflicts_with = "at")]
+        pattern: Option<String>,
+
+        /// Generate the changelog for a specific git tag
+        #[clap(short, long)]
+        at: Option<String>,
+
+        /// Generate the changelog with the given template.
+        /// Possible values are 'remote', 'full_hash', 'default' or the path to your template.
+        /// If not specified cog will use cog.toml template config or fallback to 'default'.
+        #[clap(name = "template", long, short)]
+        template: Option<String>,
+
+        /// Url to use during template generation
+        #[clap(name = "remote", long, short, requires_all(&["owner", "repository"]))]
+        remote: Option<String>,
+
+        /// Repository owner to use during template generation
+        #[clap(name = "owner", long, short, requires_all(& ["remote", "repository"]))]
+        owner: Option<String>,
+
+        /// Name of the repository used during template generation
+        #[clap(name = "repository", long, requires_all(& ["owner", "remote"]))]
+        repository: Option<String>,
+    },
+
+    /// Commit changelog from latest tag to HEAD and create new tag
+    #[clap(group = ArgGroup::new("bump-spec").required(true))]
+    Bump {
+        /// Manually set the target version
+        #[clap(long, group = "bump-spec")]
+        version: Option<String>,
+
+        /// Automatically suggest the target version
+        #[clap(short, long, group = "bump-spec")]
+        auto: bool,
+
+        /// Increment the major version
+        #[clap(short = 'M', long, group = "bump-spec")]
+        major: bool,
+
+        /// Increment the minor version
+        #[clap(short, long, group = "bump-spec")]
+        minor: bool,
+
+        /// Increment the patch version
+        #[clap(short, long, group = "bump-spec")]
+        patch: bool,
+
+        /// Set the pre-release version
+        #[clap(long)]
+        pre: Option<String>,
+
+        /// Specify the bump profile hooks to run
+        #[clap(short = 'H', long, possible_values = hook_profiles())]
+        hook_profile: Option<String>,
+
+        /// Dry-run : get the target version. No action taken
+        #[clap(short, long)]
+        dry_run: bool,
+    },
+
+    /// Install cog config files
+    Init {
+        /// path to init
+        #[clap(default_value = ".")]
+        path: PathBuf,
+    },
+
+    /// Add git hooks to the repository
+    InstallHook {
+        /// Type of hook to install
+        #[clap(possible_values = &["commit-msg", "pre-push", "all"])]
+        hook_type: String,
+    },
+
+    /// Generate shell completions
+    GenerateCompletions {
+        /// Type of completions to generate
+        #[clap(name = "type", arg_enum)]
+        shell: Shell,
+    },
+}
+
+#[derive(Args)]
+pub struct CommitArgs {
+    /// Conventional commit type
+    #[clap(name = "type", value_name = "TYPE", possible_values = commit_types())]
+    pub typ: String,
+
+    /// Commit description
+    pub message: String,
+
+    /// Conventional commit scope
+    pub scope: Option<String>,
+
+    /// Create a BREAKING CHANGE commit
+    #[clap(short = 'B', long)]
+    pub breaking_change: bool,
+
+    /// Open commit message in an editor
+    #[clap(short, long)]
+    pub edit: bool,
+}
+
+fn hook_profiles() -> Vec<&'static str> {
+    SETTINGS
+        .bump_profiles
+        .keys()
+        .map(|profile| profile.as_ref())
+        .collect()
+}
+
+pub fn commit_types() -> Vec<&'static str> {
+    COMMITS_METADATA
+        .iter()
+        .map(|(commit_type, _)| commit_type.as_ref())
+        .collect()
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,9 @@ pub mod hook;
 pub mod log;
 pub mod settings;
 
+#[cfg(feature = "cli")]
+pub mod cli;
+
 pub type CommitsMetadata = HashMap<CommitType, CommitConfig>;
 
 pub const CONFIG_PATH: &str = "cog.toml";


### PR DESCRIPTION
To generate man pages with clap_mangen the Cli struct needs to be accessible from the crate public api.
Because of this the clap app has moved to the crate library while the code responsible for handling the 
user inputs stays in the cog.rs bin file. It might be a good idea to split cocogitto into several crates
and use a cargo workspace instead of a single crate with multiple binaries.

closes #11