### PR TITLE
chore: bump clap version to 4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,35 +155,33 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.20"
+version = "4.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b71c3ce99b7611011217b366d923f1d0a7e07a92bb2dbf1e84508c673ca3bd"
+checksum = "3b1a0a4208c6c483b952ad35c6eed505fc13b46f08f631b81e828084a9318d74"
 dependencies = [
  "atty",
  "bitflags",
  "clap_derive",
  "clap_lex",
- "indexmap",
  "once_cell",
  "strsim",
  "termcolor",
- "textwrap",
 ]
 
 [[package]]
 name = "clap_complete"
-version = "3.2.4"
+version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4179da71abd56c26b54dd0c248cc081c1f43b0a1a7e8448e28e57a29baa993d"
+checksum = "11cba7abac9b56dfe2f035098cdb3a43946f276e6db83b72c4e692343f9aab9a"
 dependencies = [
  "clap",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.2.18"
+version = "4.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
+checksum = "db342ce9fda24fb191e2ed4e102055a4d381c1086a06630174cd8da8d5d917ce"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -194,9 +192,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.2.4"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
 dependencies = [
  "os_str_bytes",
 ]
@@ -519,12 +517,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-
-[[package]]
 name = "heck"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -585,16 +577,6 @@ dependencies = [
  "thread_local",
  "walkdir",
  "winapi-util",
-]
-
-[[package]]
-name = "indexmap"
-version = "1.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
-dependencies = [
- "autocfg",
- "hashbrown",
 ]
 
 [[package]]
@@ -1404,12 +1386,6 @@ name = "termtree"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "507e9898683b6c43a9aa55b64259b721b52ba226e0f3779137e50ad114a4c90b"
-
-[[package]]
-name = "textwrap"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thiserror"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,8 +34,8 @@ shell-words = "^1"
 which = "^4"
 lazy_static = "^1"
 toml = "^0"
-clap = { version = "3.1", optional = true, features = ["derive"] }
-clap_complete = { version = "3.0", optional = true }
+clap = { version = "4.0", optional = true, features = ["derive"] }
+clap_complete = { version = "4.0", optional = true }
 conventional_commit_parser = "0.9.4"
 pest = "2.1.3"
 pest_derive = "2.1.0"

--- a/src/bin/cog/commit.rs
+++ b/src/bin/cog/commit.rs
@@ -3,14 +3,16 @@ use std::fmt::Write;
 use cocogitto::COMMITS_METADATA;
 
 use anyhow::{bail, Result};
+use clap::builder::PossibleValuesParser;
 use conventional_commit_parser::commit::Separator;
 use itertools::Itertools;
 
-pub fn commit_types() -> Vec<&'static str> {
-    COMMITS_METADATA
+pub fn commit_types() -> PossibleValuesParser {
+    let types = COMMITS_METADATA
         .iter()
-        .map(|(commit_type, _)| commit_type.as_ref())
-        .collect()
+        .map(|(commit_type, _)| -> &str { commit_type.as_ref() });
+
+    types.into()
 }
 
 pub fn edit_message(


### PR DESCRIPTION
Normally I would wait a bit more with a new clap release, but this one drops some dependencies (`indexmap`, `textwrap`).

Notable changes: clap has dropped help output coloring for now.