### PR TITLE
feat: add from_latest_tag to settings

### DIFF
--- a/src/bin/cog/main.rs
+++ b/src/bin/cog/main.rs
@@ -259,11 +259,13 @@ fn main() -> Result<()> {
             ignore_merge_commits,
         } => {
             let cocogitto = CocoGitto::get()?;
+            let from_latest_tag = from_latest_tag || SETTINGS.from_latest_tag;
             let ignore_merge_commits = ignore_merge_commits || SETTINGS.ignore_merge_commits;
             cocogitto.check(from_latest_tag, ignore_merge_commits)?;
         }
         Command::Edit { from_latest_tag } => {
             let cocogitto = CocoGitto::get()?;
+            let from_latest_tag = from_latest_tag || SETTINGS.from_latest_tag;
             cocogitto.check_and_edit(from_latest_tag)?;
         }
         Command::Log {

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -27,6 +27,8 @@ pub enum HookType {
 #[serde(deny_unknown_fields)]
 pub struct Settings {
     #[serde(default)]
+    pub from_latest_tag: bool,
+    #[serde(default)]
     pub ignore_merge_commits: bool,
     #[serde(default)]
     pub branch_whitelist: Vec<String>,


### PR DESCRIPTION
Without the ability to specify the `from_latest_tag` in the settings file it is very difficult to add cocogitto to an existing repository as you need to do one of the following:

* remember to only run `cog install-hook commit-msg` otherwise your pushes can fail depending on the local and remote states
* or manually edit the hooks, defeating the nice ux of the `cog install-hook` command