### PR TITLE
fix: disable help subcommand for `cog(1)`

### DIFF
--- a/src/bin/cog/main.rs
+++ b/src/bin/cog/main.rs
@@ -476,7 +476,8 @@ fn main() -> Result<()> {
             clap_complete::generate(shell, &mut Cli::command(), "cog", &mut std::io::stdout());
         }
         Command::GenerateManpage { cmd } => {
-            let cog_cmd = Cli::command();
+            let mut cog_cmd = Cli::command();
+            cog_cmd = cog_cmd.disable_help_subcommand(true);
             let cmd = match cmd.as_str() {
                 "cog" => cog_cmd,
                 cmd => cog_cmd


### PR DESCRIPTION
Hello! 🐻

From `cog(1)`:

```
SUBCOMMANDS
       Cog-help(1)
              Print this message or the help of the given subcommand(s)
```

However, it is not possible to generate a manpage for `cog-help` since it's a built-in command:

```sh
$ cog generate-manpage help

thread 'main' panicked at 'Requested non-existent subcommand', src/bin/cog/main.rs:487:22
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

This PR disables the help subcommand for `cog(1)` thus strips the `cog-help` section from manpage.
