### PR TITLE
Manpages v2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ shell-words = "^1"
 which = "^4"
 once_cell = "^1"
 toml = "^0"
-clap = { version = "4.2.4", optional = true, features = ["derive"] }
+clap = { version = "4.2.4", optional = true, features = ["derive", "string"] }
 clap_complete = { version = "4.0", optional = true }
 clap_mangen = { version = "0.2", optional = true }
 clap_complete_nushell = { version = "0.1.8", optional = true }

--- a/docs/Packaging.md
+++ b/docs/Packaging.md
@@ -2,15 +2,11 @@
 
 ## Generating manpages
 
-`cog` has a hidden subcommand to print generated manpage to STDOUT. To generate the main manpage, run:
+`cog` has a hidden subcommand to create manpages in a specified directory:
 
-```
-cog generate-manpage cog > cog.1
+```console
+cog generate-manpages "${PWD}/gen"
 ```
 
-You can also generate manpages for subcommands by specifying the subcommand name as argument, e.g.:
-
-```
-cog generate-manpage commit > cog-commit.1
-cog generate-manpage install-hook > cog-install-hook.1
-```
+This creates the directory if it doesn't exist already (like `mkdir -p` on Linux),
+then outputs generated manpages for `cog` as well as its subcommands into files in that directory.

--- a/src/bin/cog/main.rs
+++ b/src/bin/cog/main.rs
@@ -1,4 +1,5 @@
 mod commit;
+mod mangen;
 
 use std::fs;
 use std::path::PathBuf;
@@ -294,7 +295,7 @@ enum Command {
 
     /// Generate manpage
     #[command(hide = true)]
-    GenerateManpage { cmd: String },
+    GenerateManpages { output_dir: PathBuf },
 }
 
 #[derive(Args)]
@@ -535,18 +536,8 @@ fn main() -> Result<()> {
         Command::GenerateCompletions { shell } => {
             clap_complete::generate(shell, &mut Cli::command(), "cog", &mut std::io::stdout());
         }
-        Command::GenerateManpage { cmd } => {
-            let mut cog_cmd = Cli::command();
-            cog_cmd = cog_cmd.disable_help_subcommand(true);
-            let cmd = match cmd.as_str() {
-                "cog" => cog_cmd,
-                cmd => cog_cmd
-                    .find_subcommand(cmd)
-                    .expect("Requested non-existent subcommand")
-                    .clone(),
-            };
-            let man = clap_mangen::Man::new(cmd);
-            man.render(&mut std::io::stdout())?;
+        Command::GenerateManpages { output_dir } => {
+            mangen::generate_manpages(&output_dir)?;
         }
         Command::Commit(CommitArgs {
             typ,

--- a/src/bin/cog/mangen.rs
+++ b/src/bin/cog/mangen.rs
@@ -1,0 +1,37 @@
+use std::io::Result as IoResult;
+use std::path::Path;
+
+use clap::{Command, CommandFactory};
+use clap_mangen::Man;
+
+use crate::Cli;
+
+pub fn generate_manpages(out_dir: &Path) -> IoResult<()> {
+    std::fs::create_dir_all(out_dir)?;
+
+    let cog = Cli::command();
+
+    for mut subcmd in cog.get_subcommands().filter(|c| !c.is_hide_set()).cloned() {
+        let name = subcmd.get_name();
+        let full_name = format!("cog-{}", name);
+        let man_name = format!("{}.1", full_name);
+
+        subcmd = subcmd.name(&full_name);
+
+        render_command(&out_dir.join(&man_name), subcmd)?;
+    }
+
+    render_command(&out_dir.join("cog.1"), cog)?;
+
+    Ok(())
+}
+
+fn render_command(file: &Path, cmd: Command) -> IoResult<()> {
+    let man = Man::new(cmd);
+    let mut buffer = Vec::new();
+
+    man.render(&mut buffer)?;
+    std::fs::write(file, buffer)?;
+
+    Ok(())
+}


### PR DESCRIPTION
I've taken a look at my original `cog generate-manpages` design and it seems unwieldy in hindsight. It requires unnecessary effort from a packager to manually discover subcommands and request them one by one. Also the generated manpages for subcommands are not correct since the perceived name is `foo-subcommand` instead of `cog-foo-subcommand`.

This switches to simply giving the command the directory for the output and then automatically creating all manpages ourselves.

One tidbit is having to enable the `string` clap feature in order to adjust the command names manually. This shouldn't be a big problem but I wanted to point out that it's there.

As an aside, I didn't mark this change as breaking since I don't think generating manpages should be considered a part of the main public API. I'd even be half inclined to set it as `chore` rather than `feat`.