### PR TITLE
fix: execute hooks directly instead of through sh

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -285,6 +285,7 @@ dependencies = [
  "semver",
  "serde",
  "shell-words",
+ "shlex",
  "speculoos",
  "stderrlog",
  "tempfile",
@@ -1415,6 +1416,12 @@ name = "shell-words"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
+
+[[package]]
+name = "shlex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
 name = "siphasher"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ tera = "1.15.0"
 globset = "0.4.8"
 log = "0.4.16"
 stderrlog = "0.5.1"
+shlex = "1.1.0"
 
 [dev-dependencies]
 assert_cmd = "1.0.3"

--- a/src/hook/mod.rs
+++ b/src/hook/mod.rs
@@ -261,7 +261,7 @@ mod test {
         hook.insert_versions(None, Some(&HookVersion::new(tag)))
             .unwrap();
 
-        assert_that!(hook.to_string().as_str()).is_equal_to("echo cog-v1.0.0");
+        assert_that!(hook.to_string().as_str()).is_equal_to("sh -c 'echo cog-v1.0.0'");
         Ok(())
     }
 
@@ -354,7 +354,7 @@ mod test {
             .unwrap();
 
         assert_that!(hook.to_string().as_str())
-            .is_equal_to("mvn versions:set -DnewVersion=cog-v1.1.0-SNAPSHOT");
+            .is_equal_to("mvn versions:set \"-DnewVersion=cog-v1.1.0-SNAPSHOT\"");
         Ok(())
     }
 
@@ -527,7 +527,7 @@ mod test {
         .unwrap();
 
         assert_that!(hook.to_string().as_str())
-            .is_equal_to(r#"echo "cog, version: 1.1.0, tag: cog-v1.1.0, current: 1.0.0, current_tag: cog-v1.0.0""#);
+            .is_equal_to(r#"sh -c 'echo "cog, version: 1.1.0, tag: cog-v1.1.0, current: 1.0.0, current_tag: cog-v1.0.0"'"#);
         Ok(())
     }
 }

--- a/src/hook/mod.rs
+++ b/src/hook/mod.rs
@@ -249,7 +249,7 @@ mod test {
             git commit -m "first commit";
         )?;
 
-        let mut hook = Hook::from_str("echo {{version_tag}}")?;
+        let mut hook = Hook::from_str("sh -c 'echo {{version_tag}}'")?;
 
         let tag = Tag {
             package: Some("cog".to_string()),
@@ -267,7 +267,7 @@ mod test {
 
     #[test]
     fn replace_latest_tag() -> Result<()> {
-        let mut hook = Hook::from_str("echo {{latest_tag}}")?;
+        let mut hook = Hook::from_str("sh -c 'echo {{latest_tag}}'")?;
         let tag = Tag {
             package: None,
             prefix: Some("v".to_string()),
@@ -360,21 +360,21 @@ mod test {
 
     #[test]
     fn leave_hook_untouched_when_no_version() -> Result<()> {
-        let mut hook = Hook::from_str("echo \"Hello World\"")?;
+        let mut hook = Hook::from_str("sh -c 'echo \"Hello World\"'")?;
         hook.insert_versions(None, Some(&HookVersion::new(Tag::from_str("1.0.0", None)?)))
             .unwrap();
 
-        assert_that!(hook.to_string().as_str()).is_equal_to("echo \"Hello World\"");
+        assert_that!(hook.to_string().as_str()).is_equal_to("sh -c 'echo \"Hello World\"'");
         Ok(())
     }
 
     #[test]
     fn replace_quoted_version() -> Result<()> {
-        let mut hook = Hook::from_str("echo \"{{version}}\"")?;
+        let mut hook = Hook::from_str("sh -c 'echo \"{{version}}\"'")?;
         hook.insert_versions(None, Some(&HookVersion::new(Tag::from_str("1.0.0", None)?)))
             .unwrap();
 
-        assert_that!(hook.to_string().as_str()).is_equal_to("echo \"1.0.0\"");
+        assert_that!(hook.to_string().as_str()).is_equal_to("sh -c 'echo \"1.0.0\"'");
         Ok(())
     }
 
@@ -404,7 +404,8 @@ mod test {
 
     #[test]
     fn replace_version_with_multiple_placeholders() -> Result<()> {
-        let mut hook = Hook::from_str("echo \"the latest {{latest}}, the greatest {{version}}\"")?;
+        let mut hook =
+            Hook::from_str("sh -c 'echo \"the latest {{latest}}, the greatest {{version}}\"'")?;
         hook.insert_versions(
             Some(&HookVersion::new(Tag::from_str("0.5.9", None)?)),
             Some(&HookVersion::new(Tag::from_str("1.0.0", None)?)),
@@ -419,7 +420,7 @@ mod test {
     #[test]
     fn replace_version_with_multiple_placeholders_and_increments() -> Result<()> {
         let mut hook = Hook::from_str(
-            "echo \"the latest {{latest+3major+1minor}}, the greatest {{version+2patch}}\"",
+            "sh -c 'echo \"the latest {{latest+3major+1minor}}, the greatest {{version+2patch}}\"'",
         )?;
         hook.insert_versions(
             Some(&HookVersion::new(Tag::from_str("0.5.9", None)?)),
@@ -434,20 +435,22 @@ mod test {
 
     #[test]
     fn replace_version_with_pre_and_build_metadata() -> Result<()> {
-        let mut hook =
-            Hook::from_str("echo \"the latest {{version+1major-pre.alpha-bravo+build.42}}\"")?;
+        let mut hook = Hook::from_str(
+            "sh -c 'echo \"the latest {{version+1major-pre.alpha-bravo+build.42}}\"'",
+        )?;
         hook.insert_versions(None, Some(&HookVersion::new(Tag::from_str("1.0.0", None)?)))
             .unwrap();
 
         assert_that!(hook.to_string().as_str())
-            .is_equal_to("echo \"the latest 2.0.0-pre.alpha-bravo+build.42\"");
+            .is_equal_to("sh -c 'echo \"the latest 2.0.0-pre.alpha-bravo+build.42\"'");
         Ok(())
     }
 
     #[test]
     fn replace_version_tag_with_pre_and_build_metadata() -> Result<()> {
-        let mut hook =
-            Hook::from_str("echo \"the latest {{version_tag+1major-pre.alpha-bravo+build.42}}\"")?;
+        let mut hook = Hook::from_str(
+            "sh -c 'echo \"the latest {{version_tag+1major-pre.alpha-bravo+build.42}}\"'",
+        )?;
 
         let tag = Tag {
             package: None,
@@ -500,7 +503,7 @@ mod test {
         )?;
 
         let mut hook = Hook::from_str(
-            r#"echo "{{package}}, version: {{version}}, tag: {{version_tag}}, current: {{latest}}, current_tag: {{latest_tag}}""#,
+            r#"sh -c 'echo "{{package}}, version: {{version}}, tag: {{version_tag}}, current: {{latest}}, current_tag: {{latest_tag}}"'"#,
         )?;
 
         let current = Tag {

--- a/src/hook/mod.rs
+++ b/src/hook/mod.rs
@@ -185,21 +185,21 @@ mod test {
     #[test]
     fn parse_valid_string() -> Result<()> {
         let hook = Hook::from_str("cargo bump {{version}}")?;
-        assert_that!(hook.0.as_str()).is_equal_to("cargo bump {{version}}");
+        assert_that!(hook.to_string().as_str()).is_equal_to("cargo bump {{version}}");
         Ok(())
     }
 
     #[test]
     fn parse_current_version() -> Result<()> {
         let hook = Hook::from_str("cargo bump {{version_tag}}")?;
-        assert_that!(hook.0.as_str()).is_equal_to("cargo bump {{version_tag}}");
+        assert_that!(hook.to_string().as_str()).is_equal_to("cargo bump {{version_tag}}");
         Ok(())
     }
 
     #[test]
     fn parse_latest_tag() -> Result<()> {
         let hook = Hook::from_str("cargo bump {{latest_tag}}")?;
-        assert_that!(hook.0.as_str()).is_equal_to("cargo bump {{latest_tag}}");
+        assert_that!(hook.to_string().as_str()).is_equal_to("cargo bump {{latest_tag}}");
         Ok(())
     }
 
@@ -209,7 +209,7 @@ mod test {
         hook.insert_versions(None, Some(&HookVersion::new(Tag::from_str("1.0.0", None)?)))
             .unwrap();
 
-        assert_that!(hook.0.as_str()).is_equal_to("cargo bump 1.0.0");
+        assert_that!(hook.to_string().as_str()).is_equal_to("cargo bump 1.0.0");
         Ok(())
     }
 
@@ -226,7 +226,7 @@ mod test {
         hook.insert_versions(None, Some(&HookVersion::new(tag)))
             .unwrap();
 
-        assert_that!(hook.0.as_str()).is_equal_to("cargo bump v1.0.0");
+        assert_that!(hook.to_string().as_str()).is_equal_to("cargo bump v1.0.0");
         Ok(())
     }
 
@@ -260,7 +260,7 @@ mod test {
         hook.insert_versions(None, Some(&HookVersion::new(tag)))
             .unwrap();
 
-        assert_that!(hook.0.as_str()).is_equal_to("echo cog-v1.0.0");
+        assert_that!(hook.to_string().as_str()).is_equal_to("echo cog-v1.0.0");
         Ok(())
     }
 
@@ -277,7 +277,7 @@ mod test {
         hook.insert_versions(Some(&HookVersion::new(tag)), None)
             .unwrap();
 
-        assert_that!(hook.0.as_str()).is_equal_to("echo v1.0.0");
+        assert_that!(hook.to_string().as_str()).is_equal_to("echo v1.0.0");
         Ok(())
     }
 
@@ -287,7 +287,7 @@ mod test {
         hook.insert_versions(None, Some(&HookVersion::new(Tag::from_str("1.0.0", None)?)))
             .unwrap();
 
-        assert_that!(hook.0.as_str()).is_equal_to("mvn versions:set -DnewVersion=1.0.0");
+        assert_that!(hook.to_string().as_str()).is_equal_to("mvn versions:set -DnewVersion=1.0.0");
         Ok(())
     }
 
@@ -297,7 +297,8 @@ mod test {
         hook.insert_versions(None, Some(&HookVersion::new(Tag::from_str("1.0.0", None)?)))
             .unwrap();
 
-        assert_that!(hook.0.as_str()).is_equal_to("mvn versions:set -DnewVersion=1.1.0-SNAPSHOT");
+        assert_that!(hook.to_string().as_str())
+            .is_equal_to("mvn versions:set -DnewVersion=1.1.0-SNAPSHOT");
         Ok(())
     }
 
@@ -315,7 +316,8 @@ mod test {
         hook.insert_versions(None, Some(&HookVersion::new(tag)))
             .unwrap();
 
-        assert_that!(hook.0.as_str()).is_equal_to("mvn versions:set -DnewVersion=v1.1.0-SNAPSHOT");
+        assert_that!(hook.to_string().as_str())
+            .is_equal_to("mvn versions:set -DnewVersion=v1.1.0-SNAPSHOT");
         Ok(())
     }
 
@@ -350,7 +352,7 @@ mod test {
         hook.insert_versions(None, Some(&HookVersion::new(tag)))
             .unwrap();
 
-        assert_that!(hook.0.as_str())
+        assert_that!(hook.to_string().as_str())
             .is_equal_to("mvn versions:set -DnewVersion=cog-v1.1.0-SNAPSHOT");
         Ok(())
     }
@@ -361,7 +363,7 @@ mod test {
         hook.insert_versions(None, Some(&HookVersion::new(Tag::from_str("1.0.0", None)?)))
             .unwrap();
 
-        assert_that!(hook.0.as_str()).is_equal_to("echo \"Hello World\"");
+        assert_that!(hook.to_string().as_str()).is_equal_to("echo \"Hello World\"");
         Ok(())
     }
 
@@ -371,7 +373,7 @@ mod test {
         hook.insert_versions(None, Some(&HookVersion::new(Tag::from_str("1.0.0", None)?)))
             .unwrap();
 
-        assert_that!(hook.0.as_str()).is_equal_to("echo \"1.0.0\"");
+        assert_that!(hook.to_string().as_str()).is_equal_to("echo \"1.0.0\"");
         Ok(())
     }
 
@@ -382,7 +384,8 @@ mod test {
         hook.insert_versions(None, Some(&HookVersion::new(Tag::from_str("1.0.0", None)?)))
             .unwrap();
 
-        assert_that!(hook.0.as_str()).is_equal_to("cog commit chore 'bump snapshot to 1.1.0-pre'");
+        assert_that!(hook.to_string().as_str())
+            .is_equal_to("cog commit chore 'bump snapshot to 1.1.0-pre'");
         Ok(())
     }
 
@@ -393,7 +396,7 @@ mod test {
         hook.insert_versions(None, Some(&HookVersion::new(Tag::from_str("1.0.0", None)?)))
             .unwrap();
 
-        assert_that!(hook.0.as_str())
+        assert_that!(hook.to_string().as_str())
             .is_equal_to("cog commit chore \"bump snapshot to 1.1.0-pre\"");
         Ok(())
     }
@@ -407,7 +410,8 @@ mod test {
         )
         .unwrap();
 
-        assert_that!(hook.0.as_str()).is_equal_to("echo \"the latest 0.5.9, the greatest 1.0.0\"");
+        assert_that!(hook.to_string().as_str())
+            .is_equal_to("echo \"the latest 0.5.9, the greatest 1.0.0\"");
         Ok(())
     }
 
@@ -422,7 +426,8 @@ mod test {
         )
         .unwrap();
 
-        assert_that!(hook.0.as_str()).is_equal_to("echo \"the latest 3.1.0, the greatest 1.0.2\"");
+        assert_that!(hook.to_string().as_str())
+            .is_equal_to("echo \"the latest 3.1.0, the greatest 1.0.2\"");
         Ok(())
     }
 
@@ -433,7 +438,7 @@ mod test {
         hook.insert_versions(None, Some(&HookVersion::new(Tag::from_str("1.0.0", None)?)))
             .unwrap();
 
-        assert_that!(hook.0.as_str())
+        assert_that!(hook.to_string().as_str())
             .is_equal_to("echo \"the latest 2.0.0-pre.alpha-bravo+build.42\"");
         Ok(())
     }
@@ -453,7 +458,7 @@ mod test {
         hook.insert_versions(None, Some(&HookVersion::new(tag)))
             .unwrap();
 
-        assert_that!(hook.0.as_str())
+        assert_that!(hook.to_string().as_str())
             .is_equal_to("echo \"the latest v2.0.0-pre.alpha-bravo+build.42\"");
 
         Ok(())
@@ -517,7 +522,7 @@ mod test {
         )
         .unwrap();
 
-        assert_that!(hook.0.as_str())
+        assert_that!(hook.to_string().as_str())
             .is_equal_to(r#"echo "cog, version: 1.1.0, tag: cog-v1.1.0, current: 1.0.0, current_tag: cog-v1.0.0""#);
         Ok(())
     }

--- a/src/hook/mod.rs
+++ b/src/hook/mod.rs
@@ -149,7 +149,7 @@ impl Hook {
     }
 
     pub fn run(&self, package_path: Option<&path::Path>) -> Result<()> {
-        let exe = &self.0.first().unwrap();
+        let exe = which::which(self.0.first().unwrap()).unwrap();
         let args: Vec<String> = self.0.clone().into_iter().skip(1).collect();
         let mut cmd = Command::new(&exe);
         cmd.args(&args);

--- a/src/hook/mod.rs
+++ b/src/hook/mod.rs
@@ -129,7 +129,8 @@ impl FromStr for Hook {
 
 impl fmt::Display for Hook {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str(&self.0.join(" "))
+        let parts = self.0.iter().map(|s| s.as_str());
+        f.write_str(shlex::join(parts).as_str())
     }
 }
 


### PR DESCRIPTION
On Windows my hooks weren't being ran. I noticed it was because `sh` was being used. I instead made the hook accept a list where the assumption is the first element in the list is the program and the rest are the arguments.

It works well for me, but the tests are failing because they assume everything is passed through `sh -c`. If this change is acceptable I can attempt to update the rest of the tests.

This is technically a breaking change, but what do you think?