### PR TITLE
style: rename 'Cog' to 'cog' internally

### DIFF
--- a/src/bin/cog/main.rs
+++ b/src/bin/cog/main.rs
@@ -115,7 +115,7 @@ impl ValueEnum for Shell {
 #[derive(Parser)]
 #[command(
     version,
-    name = "Cog",
+    name = "cog",
     author = "Paul D. <paul.delafosse@protonmail.com>"
 )]
 struct Cli {


### PR DESCRIPTION
This makes the manpages and help outputs a little more cohesive.