### PR TITLE
refactor(revspec): raise error instead of panicking when parsing `RevspecPattern`

### DIFF
--- a/cog.toml
+++ b/cog.toml
@@ -86,5 +86,6 @@ authors = [
     { signature = "Luca Trevisani", username = "lucatrv" },
     { signature = "Racci", username = "DaRacci" },
     { signature = "Conrad Hoffmann", username = "bitfehler" },
-    { signature = "andre161292", username = "andre161292" }
+    { signature = "andre161292", username = "andre161292" },
+    { signature = "Sanchith Hegde", username = "SanchithHegde" }
 ]

--- a/src/bin/cog/main.rs
+++ b/src/bin/cog/main.rs
@@ -3,6 +3,7 @@ mod mangen;
 
 use std::fs;
 use std::path::PathBuf;
+use std::str::FromStr;
 
 use cocogitto::conventional::changelog::template::{RemoteContext, Template};
 use cocogitto::conventional::commit as conv_commit;
@@ -523,7 +524,10 @@ fn main() -> Result<()> {
                 Template::default()
             };
 
-            let pattern = pattern.as_deref().map(RevspecPattern::from);
+            let pattern = pattern
+                .as_deref()
+                .map(RevspecPattern::from_str)
+                .transpose()?;
 
             let result = match at {
                 Some(at) => cocogitto.get_changelog_at_tag(&at, template)?,

--- a/src/command/changelog.rs
+++ b/src/command/changelog.rs
@@ -4,6 +4,7 @@ use crate::git::revspec::RevspecPattern;
 use crate::CocoGitto;
 use anyhow::anyhow;
 use anyhow::Result;
+use std::str::FromStr;
 
 impl CocoGitto {
     /// ## Get a changelog between two oids
@@ -27,7 +28,7 @@ impl CocoGitto {
 
     pub fn get_changelog_at_tag(&self, tag: &str, template: Template) -> Result<String> {
         let pattern = format!("..{tag}");
-        let pattern = RevspecPattern::from(pattern.as_str());
+        let pattern = RevspecPattern::from_str(pattern.as_str())?;
         let changelog = self.get_changelog(pattern, false)?;
 
         changelog

--- a/src/command/check.rs
+++ b/src/command/check.rs
@@ -6,6 +6,7 @@ use anyhow::anyhow;
 use anyhow::Result;
 use colored::*;
 use log::info;
+use std::str::FromStr;
 
 impl CocoGitto {
     pub fn check(
@@ -16,7 +17,7 @@ impl CocoGitto {
     ) -> Result<()> {
         let commit_range = if let Some(range) = range {
             self.repository
-                .get_commit_range(&RevspecPattern::from(range.as_str()))?
+                .get_commit_range(&RevspecPattern::from_str(range.as_str())?)?
         } else if check_from_latest_tag {
             self.repository
                 .get_commit_range(&RevspecPattern::default())?

--- a/src/conventional/bump.rs
+++ b/src/conventional/bump.rs
@@ -5,6 +5,7 @@ use conventional_commit_parser::commit::CommitType;
 use git2::Commit as Git2Commit;
 use once_cell::sync::Lazy;
 use semver::{BuildMetadata, Prerelease, Version};
+use std::str::FromStr;
 
 static FILTER_MERGE_COMMITS: Lazy<fn(&&git2::Commit) -> bool> = Lazy::new(|| {
     |commit| {
@@ -146,7 +147,7 @@ impl Tag {
             .map(|oid| format!("{oid}.."))
             .unwrap_or_else(|| "..".to_string());
         let pattern = pattern.as_str();
-        let pattern = RevspecPattern::from(pattern);
+        let pattern = RevspecPattern::from_str(pattern)?;
         let commits = repository.get_commit_range(&pattern)?;
 
         let commits: Vec<&Git2Commit> = commits
@@ -189,7 +190,7 @@ impl Tag {
             .map(|oid| format!("{oid}.."))
             .unwrap_or_else(|| "..".to_string());
         let pattern = pattern.as_str();
-        let pattern = RevspecPattern::from(pattern);
+        let pattern = RevspecPattern::from_str(pattern)?;
         let commits = repository.get_commit_range_for_package(&pattern, package)?;
         let commits: Vec<&Git2Commit> = commits
             .commits
@@ -229,7 +230,7 @@ impl Tag {
             .map(|oid| format!("{oid}.."))
             .unwrap_or_else(|| "..".to_string());
         let pattern = pattern.as_str();
-        let pattern = RevspecPattern::from(pattern);
+        let pattern = RevspecPattern::from_str(pattern)?;
         let commits = repository.get_commit_range_for_monorepo_global(&pattern)?;
 
         let commits: Vec<&Git2Commit> = commits

--- a/src/git/error.rs
+++ b/src/git/error.rs
@@ -26,6 +26,7 @@ pub enum Git2Error {
     CommitterNotFound,
     TagError(TagError),
     GitHookNonZeroExit(i32),
+    InvalidCommitRangePattern(String),
 }
 
 #[derive(Debug)]
@@ -121,6 +122,9 @@ impl Display for Git2Error {
             Git2Error::GpgError(_) => writeln!(f, "failed to sign commit"),
             Git2Error::GitHookNonZeroExit(status) => {
                 writeln!(f, "commit hook failed with exit code {status}")
+            }
+            Git2Error::InvalidCommitRangePattern(pattern) => {
+                writeln!(f, "invalid commit range pattern: `{pattern}`")
             }
         }?;
 

--- a/src/git/monorepo.rs
+++ b/src/git/monorepo.rs
@@ -27,6 +27,7 @@ mod test {
     use indoc::formatdoc;
     use sealed_test::prelude::*;
     use speculoos::prelude::*;
+    use std::str::FromStr;
 
     #[sealed_test]
     fn get_repo_packages() -> Result<()> {
@@ -67,7 +68,8 @@ mod test {
         )?;
 
         // Act
-        let range = repo.get_commit_range_for_package(&RevspecPattern::from("..HEAD"), "two")?;
+        let range =
+            repo.get_commit_range_for_package(&RevspecPattern::from_str("..HEAD")?, "two")?;
 
         // Assert
         assert_that!(range)

--- a/src/git/revspec.rs
+++ b/src/git/revspec.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 use std::fmt::Formatter;
+use std::str::FromStr;
 
 use git2::{Commit, ErrorCode, Oid};
 
@@ -31,27 +32,27 @@ impl fmt::Display for RevspecPattern {
     }
 }
 
-impl From<&str> for RevspecPattern {
-    fn from(value: &str) -> Self {
-        if !value.contains("..") {
-            panic!("Invalid commit range pattern: '{value}'");
+impl FromStr for RevspecPattern {
+    type Err = Git2Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if let Some((from, to)) = s.split_once("..") {
+            let from = if from.is_empty() {
+                None
+            } else {
+                Some(from.to_string())
+            };
+
+            let to = if to.is_empty() {
+                None
+            } else {
+                Some(to.to_string())
+            };
+
+            Ok(RevspecPattern { from, to })
+        } else {
+            Err(Git2Error::InvalidCommitRangePattern(s.to_string()))
         }
-
-        let split = value.split("..").collect::<Vec<&str>>();
-
-        let from = if split[0].is_empty() {
-            None
-        } else {
-            Some(split[0].to_string())
-        };
-
-        let to = if split[1].is_empty() {
-            None
-        } else {
-            Some(split[1].to_string())
-        };
-
-        RevspecPattern { from, to }
     }
 }
 
@@ -131,7 +132,7 @@ impl Repository {
         target: &Oid,
     ) -> Result<Release<'a>, Git2Error> {
         let pattern = format!("..{}", release.from);
-        let pattern = RevspecPattern::from(pattern.as_str());
+        let pattern = RevspecPattern::from_str(pattern.as_str())?;
         let range = self.get_commit_range(&pattern)?;
 
         let target_in_range = range.commits.iter().any(|commit| commit.id() == *target);
@@ -399,6 +400,7 @@ mod test {
     use speculoos::prelude::*;
     use std::collections::HashMap;
     use std::path::PathBuf;
+    use std::str::FromStr;
 
     use crate::git::oid::OidOf;
     use crate::git::repository::Repository;
@@ -409,42 +411,49 @@ mod test {
     const COCOGITTO_REPOSITORY: &str = env!("CARGO_MANIFEST_DIR");
 
     #[test]
-    fn convert_str_to_pattern_to() {
-        let pattern = RevspecPattern::from("..1.0.0");
+    fn convert_str_to_pattern_to() -> Result<()> {
+        let pattern = RevspecPattern::from_str("..1.0.0")?;
 
         assert_that!(pattern.from).is_none();
         assert_that!(pattern.to)
             .is_some()
             .is_equal_to("1.0.0".to_string());
+        Ok(())
     }
 
     #[test]
-    fn convert_str_to_pattern_from() {
-        let pattern = RevspecPattern::from("1.0.0..");
+    fn convert_str_to_pattern_from() -> Result<()> {
+        let pattern = RevspecPattern::from_str("1.0.0..")?;
 
         assert_that!(pattern.from)
             .is_some()
             .is_equal_to("1.0.0".to_string());
-        assert_that!(pattern.to).is_none()
+        assert_that!(pattern.to).is_none();
+        Ok(())
     }
 
     #[test]
-    fn convert_empty_pattern() {
-        let pattern = RevspecPattern::from("..");
+    fn convert_empty_pattern() -> Result<()> {
+        let pattern = RevspecPattern::from_str("..")?;
 
         assert_that!(pattern.from).is_none();
-        assert_that!(pattern.to).is_none()
+        assert_that!(pattern.to).is_none();
+        Ok(())
     }
 
     #[test]
-    #[should_panic(expected = "Invalid commit range pattern: '1.0.0'")]
-    fn panic_invalid_pattern() {
-        let _ = RevspecPattern::from("1.0.0");
+    fn error_invalid_pattern() {
+        let result = RevspecPattern::from_str("1.0.0");
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "invalid commit range pattern: `1.0.0`\n"
+        );
     }
 
     #[test]
-    fn convert_full_pattern() {
-        let pattern = RevspecPattern::from("1.0.0..2.0.0");
+    fn convert_full_pattern() -> Result<()> {
+        let pattern = RevspecPattern::from_str("1.0.0..2.0.0")?;
 
         assert_that!(pattern.from)
             .is_some()
@@ -452,6 +461,7 @@ mod test {
         assert_that!(pattern.to)
             .is_some()
             .is_equal_to("2.0.0".to_string());
+        Ok(())
     }
 
     #[test]
@@ -474,7 +484,7 @@ mod test {
         let format_version = |release: &Release| format!("{}", release.version);
 
         // Act
-        let release = repo.get_release_range(RevspecPattern::from("0.32.1..0.32.3"))?;
+        let release = repo.get_release_range(RevspecPattern::from_str("0.32.1..0.32.3")?)?;
 
         // Assert
         assert_that!(format_version(&release)).is_equal_to("0.32.3".to_string());
@@ -520,7 +530,7 @@ mod test {
 
         repo.commit("feat: a commit", false)?;
 
-        let commit_range = repo.get_commit_range(&RevspecPattern::from("..1.0.0"))?;
+        let commit_range = repo.get_commit_range(&RevspecPattern::from_str("..1.0.0")?)?;
 
         assert_that!(commit_range.from).is_equal_to(OidOf::Other(start));
         assert_that!(commit_range.to.to_string()).is_equal_to("1.0.0".to_string());
@@ -563,9 +573,9 @@ mod test {
         )?;
 
         let commit_range_package =
-            repo.get_commit_range_for_package(&RevspecPattern::from("..HEAD"), "one")?;
+            repo.get_commit_range_for_package(&RevspecPattern::from_str("..HEAD")?, "one")?;
         let commit_range_global =
-            repo.get_commit_range_for_monorepo_global(&RevspecPattern::from("..HEAD"))?;
+            repo.get_commit_range_for_monorepo_global(&RevspecPattern::from_str("..HEAD")?)?;
 
         assert_that!(commit_range_package.commits).has_length(1);
         assert_that!(commit_range_global.commits).has_length(1);
@@ -592,7 +602,7 @@ mod test {
         )?;
 
         // Act
-        let commit_range = repo.get_commit_range(&RevspecPattern::from("..1.0.0"))?;
+        let commit_range = repo.get_commit_range(&RevspecPattern::from_str("..1.0.0")?)?;
 
         // Assert
         assert_that!(commit_range.from).is_equal_to(OidOf::Other(start));
@@ -611,7 +621,7 @@ mod test {
         let v3_0_0 = OidOf::Tag(Tag::from_str("3.0.0", Some(v3_0_0))?);
 
         // Act
-        let range = repo.get_commit_range(&RevspecPattern::from("1.0.0..3.0.0"))?;
+        let range = repo.get_commit_range(&RevspecPattern::from_str("1.0.0..3.0.0")?)?;
 
         // Assert
         assert_that!(range.from).is_equal_to(v1_0_0);
@@ -639,7 +649,7 @@ mod test {
         let v1_0_0 = OidOf::Tag(Tag::from_str("1.0.0", Some(v1_0_0))?);
 
         // Act
-        let range = repo.get_commit_range(&RevspecPattern::from("1.0.0.."))?;
+        let range = repo.get_commit_range(&RevspecPattern::from_str("1.0.0..")?)?;
 
         // Assert
         assert_that!(range.from).is_equal_to(v1_0_0);
@@ -684,7 +694,7 @@ mod test {
         let v3_0_0 = OidOf::Tag(Tag::from_str("3.0.0", Some(v3_0_0))?);
 
         // Act
-        let range = repo.get_commit_range(&RevspecPattern::from("..3.0.0"))?;
+        let range = repo.get_commit_range(&RevspecPattern::from_str("..3.0.0")?)?;
 
         // Assert
         assert_that!(range.from).is_equal_to(v2_1_1);
@@ -706,7 +716,7 @@ mod test {
         };
 
         // Act
-        let mut release = repo.get_release_range(RevspecPattern::from(".."))?;
+        let mut release = repo.get_release_range(RevspecPattern::from_str("..")?)?;
         let mut count = 0;
 
         while let Some(previous) = release.previous {
@@ -750,7 +760,7 @@ mod test {
         let pattern = format!("{}..", &from[0..7]);
 
         // Act
-        let release = repo.get_release_range(RevspecPattern::from(pattern.as_str()))?;
+        let release = repo.get_release_range(RevspecPattern::from_str(pattern.as_str())?)?;
 
         // Assert
         let oids: Vec<String> = release
@@ -795,7 +805,7 @@ mod test {
         let pattern = format!("{}..", &from[0..7]);
 
         // Act
-        let release = repo.get_release_range(RevspecPattern::from(pattern.as_str()))?;
+        let release = repo.get_release_range(RevspecPattern::from_str(pattern.as_str())?)?;
 
         // Assert
         let head_to_v1: Vec<String> = release


### PR DESCRIPTION
This PR updates the parsing logic for `RevspecPattern` to raise an error instead of panicking, by replacing the `From<&str>` implementation with `FromStr`, as discussed in https://github.com/cocogitto/cocogitto/pull/286#issue-1718201238.

Let me know if using a separate error enum/struct would be preferable instead of adding an enum variant to `Git2Error`, and if a `TryFrom` implementation would also be required.