### PR TITLE
feat: gha bot support

### DIFF
--- a/src/conventional/commit.rs
+++ b/src/conventional/commit.rs
@@ -1,7 +1,7 @@
 use std::cmp::Ordering;
 use std::fmt::{self, Formatter};
 
-use crate::conventional::error::ConventionalCommitError;
+pub use crate::conventional::error::ConventionalCommitError;
 use crate::SETTINGS;
 use chrono::{NaiveDateTime, Utc};
 use colored::*;

--- a/src/conventional/error.rs
+++ b/src/conventional/error.rs
@@ -6,7 +6,7 @@ use serde::de::StdError;
 use std::fmt;
 use std::fmt::{Display, Formatter};
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum ConventionalCommitError {
     CommitFormat {
         oid: String,

--- a/src/settings/error.rs
+++ b/src/settings/error.rs
@@ -3,7 +3,7 @@ use serde::de::StdError;
 use std::fmt::{Debug, Display, Formatter};
 
 #[derive(Debug)]
-pub(crate) struct SettingError(config::ConfigError);
+pub struct SettingError(config::ConfigError);
 
 impl Display for SettingError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -11,7 +11,7 @@ use crate::conventional::changelog::error::ChangelogError;
 use crate::conventional::changelog::template::{RemoteContext, Template};
 use crate::hook::Hooks;
 use crate::settings::error::SettingError;
-use config::{Config, File};
+use config::{Config, File, FileFormat};
 use conventional_commit_parser::commit::CommitType;
 use serde::{Deserialize, Serialize};
 use std::path::Path;
@@ -264,23 +264,10 @@ pub struct BumpProfile {
 
 impl Settings {
     // Fails only if config exists and is malformed
-    pub(crate) fn get(repository: &Repository) -> Result<Self, SettingError> {
-        match repository.get_repo_dir() {
-            Some(repo_path) => {
-                let settings_path = repo_path.join(CONFIG_PATH);
-                if settings_path.exists() {
-                    Config::builder()
-                        .add_source(File::from(settings_path))
-                        .build()
-                        .map_err(SettingError::from)?
-                        .try_deserialize()
-                        .map_err(SettingError::from)
-                } else {
-                    Ok(Settings::default())
-                }
-            }
-            None => Ok(Settings::default()),
-        }
+    pub(crate) fn get<T: TryInto<Settings, Error = SettingError>>(
+        repository: T,
+    ) -> Result<Self, SettingError> {
+        repository.try_into()
     }
 
     pub fn commit_types(&self) -> CommitsMetadata {
@@ -413,5 +400,45 @@ impl Hooks for MonoRepoPackage {
         self.post_bump_hooks
             .as_ref()
             .unwrap_or(&SETTINGS.post_package_bump_hooks)
+    }
+}
+
+impl TryFrom<String> for Settings {
+    type Error = SettingError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        if value.is_empty() {
+            Ok(Settings::default())
+        } else {
+            Config::builder()
+                .add_source(File::from_str(&value, FileFormat::Toml))
+                .build()
+                .map_err(SettingError::from)?
+                .try_deserialize()
+                .map_err(SettingError::from)
+        }
+    }
+}
+
+impl TryFrom<&Repository> for Settings {
+    type Error = SettingError;
+
+    fn try_from(repo: &Repository) -> Result<Self, Self::Error> {
+        match repo.get_repo_dir() {
+            Some(repo_path) => {
+                let settings_path = repo_path.join(CONFIG_PATH);
+                if settings_path.exists() {
+                    Config::builder()
+                        .add_source(File::from(settings_path))
+                        .build()
+                        .map_err(SettingError::from)?
+                        .try_deserialize()
+                        .map_err(SettingError::from)
+                } else {
+                    Ok(Settings::default())
+                }
+            }
+            None => Ok(Settings::default()),
+        }
     }
 }


### PR DESCRIPTION
PR makes minor changes to internal implementation details in support of deprecating the [Cocogitto GitHub Bot](https://github.com/cocogitto/cocogitto-bot/pull/13)'s use of `conventional_commit_parser` in favor of using Cocogitto itself to validate commit messages.