### PR TITLE
feat: add option to overwrite existing git-hooks

### DIFF
--- a/src/bin/cog/main.rs
+++ b/src/bin/cog/main.rs
@@ -306,6 +306,9 @@ enum Command {
         /// Install all git-hooks
         #[arg(short, long, group = "git-hooks")]
         all: bool,
+        /// Overwrite existing git-hooks
+        #[arg(short, long)]
+        overwrite: bool,
     },
 
     /// Generate shell completions
@@ -560,16 +563,17 @@ fn main() -> Result<()> {
         Command::InstallHook {
             hook_type: hook_types,
             all,
+            overwrite,
         } => {
             let cocogitto = CocoGitto::get()?;
             if all {
-                cocogitto.install_all_hooks()?;
+                cocogitto.install_all_hooks(overwrite)?;
                 return Ok(());
             };
 
             let hook_types = hook_types.into_iter().map(GitHookType::from).collect();
 
-            cocogitto.install_git_hooks(hook_types)?;
+            cocogitto.install_git_hooks(overwrite, hook_types)?;
         }
         Command::GenerateCompletions { shell } => {
             clap_complete::generate(shell, &mut Cli::command(), "cog", &mut std::io::stdout());

--- a/src/command/git_hooks.rs
+++ b/src/command/git_hooks.rs
@@ -4,7 +4,7 @@ use crate::{CocoGitto, SETTINGS};
 use anyhow::{anyhow, Result};
 
 impl CocoGitto {
-    pub fn install_all_hooks(&self) -> Result<()> {
+    pub fn install_all_hooks(&self, overwrite_existing_hooks: bool) -> Result<()> {
         let repodir = &self
             .repository
             .get_repo_dir()
@@ -12,13 +12,17 @@ impl CocoGitto {
             .to_path_buf();
 
         for (hook_type, hook) in SETTINGS.git_hooks.iter() {
-            install_git_hook(repodir, hook_type, hook)?;
+            install_git_hook(repodir, overwrite_existing_hooks, hook_type, hook)?;
         }
 
         Ok(())
     }
 
-    pub fn install_git_hooks(&self, hook_types: Vec<GitHookType>) -> Result<()> {
+    pub fn install_git_hooks(
+        &self,
+        overwrite_existing_hooks: bool,
+        hook_types: Vec<GitHookType>,
+    ) -> Result<()> {
         let repodir = &self
             .repository
             .get_repo_dir()
@@ -30,7 +34,7 @@ impl CocoGitto {
                 .git_hooks
                 .get(&hook_type)
                 .ok_or(anyhow!("git-hook {hook_type} was not found in cog.toml"))?;
-            install_git_hook(repodir, &hook_type, hook)?
+            install_git_hook(repodir, overwrite_existing_hooks, &hook_type, hook)?
         }
 
         Ok(())

--- a/src/git/hook.rs
+++ b/src/git/hook.rs
@@ -7,11 +7,16 @@ use std::path::Path;
 use crate::settings::{GitHook, GitHookType};
 use anyhow::Result;
 
-pub fn install_git_hook(repodir: &Path, hook_type: &GitHookType, hook: &GitHook) -> Result<()> {
+pub fn install_git_hook(
+    repodir: &Path,
+    overwrite_existing_hooks: bool,
+    hook_type: &GitHookType,
+    hook: &GitHook,
+) -> Result<()> {
     let hook_path = repodir.join(".git/hooks");
     let hook_path = hook_path.join::<&str>((*hook_type).into());
 
-    if hook_path.exists() {
+    if !overwrite_existing_hooks && hook_path.exists() {
         let mut answer = String::new();
         println!(
             "Git hook `{}` exists. (Overwrite Y/n)",
@@ -87,7 +92,7 @@ exit 1"#
         let cog = CocoGitto::get()?;
 
         // Act
-        cog.install_git_hooks(vec![GitHookType::CommitMsg])?;
+        cog.install_git_hooks(true, vec![GitHookType::CommitMsg])?;
 
         // Assert
         assert_that!(Path::new(".git/hooks/commit-msg")).exists();
@@ -138,7 +143,7 @@ exit 1"#
         let cog = CocoGitto::get()?;
 
         // Act
-        cog.install_all_hooks()?;
+        cog.install_all_hooks(true)?;
 
         // Assert
         assert_that!(Path::new(".git/hooks/commit-msg")).exists();


### PR DESCRIPTION
This PR adds a command line option to overwrite existing git-hooks for the `install-hook` command, as requested in #299.