### PR TITLE
feat: version access substitution

### DIFF
--- a/src/hook/parser.rs
+++ b/src/hook/parser.rs
@@ -14,6 +14,13 @@ use semver::{BuildMetadata, Prerelease};
 struct HookDslParser;
 
 #[derive(Debug, Eq, PartialEq)]
+pub enum VersionAccessToken {
+    Major,
+    Minor,
+    Patch,
+}
+
+#[derive(Debug, Eq, PartialEq)]
 pub enum Token {
     Version,
     VersionTag,
@@ -27,6 +34,7 @@ pub enum Token {
     Patch,
     PreRelease(Prerelease),
     BuildMetadata(BuildMetadata),
+    VersionAccess(VersionAccessToken),
 }
 
 pub fn parse(hook: &str) -> Result<HookSpan, HookParseError> {
@@ -72,6 +80,15 @@ fn parse_version(pair: Pair<Rule>) -> Result<VersionSpan, HookParseError> {
                 let identifiers = pair.into_inner().next().unwrap();
                 let semver_build_meta = BuildMetadata::new(identifiers.as_str())?;
                 tokens.push_back(Token::BuildMetadata(semver_build_meta));
+            }
+            Rule::version_access_major => {
+                tokens.push_back(Token::VersionAccess(VersionAccessToken::Major))
+            }
+            Rule::version_access_minor => {
+                tokens.push_back(Token::VersionAccess(VersionAccessToken::Minor))
+            }
+            Rule::version_access_patch => {
+                tokens.push_back(Token::VersionAccess(VersionAccessToken::Patch))
             }
             _ => (),
         }

--- a/src/hook/version_dsl.pest
+++ b/src/hook/version_dsl.pest
@@ -17,6 +17,10 @@ major = { "major" }
 minor = { "minor" }
 patch = { "patch" }
 
+version_access_major = { dot ~ "major" }
+version_access_minor = { dot ~ "minor" }
+version_access_patch = { dot ~ "patch" }
+
 amt = { NUMBER }
 ops = { add ~ amt? ~ ( major | minor | patch ) }
 ASCII_ALPHA_OR_HYPHEN = { ASCII_ALPHA | NUMBER | "-" }
@@ -35,5 +39,5 @@ package = { "package" }
 version = { delimiter_start ~ (
         ((current_tag | current_version | latest_tag | latest_version) ~ ops* ~ pre_release? ~ build_metadata?)
         | package
-    ) ~ delimiter_end}
+    ) ~ ( version_access_major | version_access_minor | version_access_patch )? ~ delimiter_end}
 version_dsl = { SOI ~ ( version | (!delimiter_start ~ ANY) )* ~ EOI }


### PR DESCRIPTION
Adds the ability to do `{{version.major}}` `{{version.minor}}` or `{{version.patch}}` in hook.

Here's an example on how I use it: https://github.com/ecsact-dev/ecsact_parse/blob/main/cog.toml

I didn't add tests, but I'm happy to if this is an acceptable change. Let me know!