### PR TITLE
feat: allow setting config file path through env var

### DIFF
--- a/src/command/init.rs
+++ b/src/command/init.rs
@@ -34,15 +34,16 @@ pub fn init<S: AsRef<Path> + ?Sized>(path: &S) -> anyhow::Result<()> {
     };
 
     let settings = Settings::default();
-    let settings_path = path.join(CONFIG_PATH);
+    let settings_path = path.join(CONFIG_PATH.as_str());
     if settings_path.exists() {
-        eprint!("Found {} in {:?}, Nothing to do", CONFIG_PATH, &path);
+        eprint!("Found {} in {:?}, Nothing to do", *(CONFIG_PATH), &path);
         exit(1);
     } else {
         std::fs::write(
             &settings_path,
-            toml::to_string(&settings)
-                .map_err(|err| anyhow!("failed to serialize {}\n\ncause: {}", CONFIG_PATH, err))?,
+            toml::to_string(&settings).map_err(|err| {
+                anyhow!("failed to serialize {}\n\ncause: {}", *(CONFIG_PATH), err)
+            })?,
         )
         .map_err(|err| {
             anyhow!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::env;
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
 
@@ -30,7 +31,15 @@ pub mod settings;
 
 pub type CommitsMetadata = HashMap<CommitType, CommitConfig>;
 
-pub const CONFIG_PATH: &str = "cog.toml";
+pub const DEFAULT_CONFIG_PATH: &str = "cog.toml";
+
+pub static CONFIG_PATH: Lazy<String> = Lazy::new(|| {
+    if let Ok(val) = env::var("COG_CONFIG_PATH") {
+        val
+    } else {
+        DEFAULT_CONFIG_PATH.to_string()
+    }
+});
 
 pub static SETTINGS: Lazy<Settings> = Lazy::new(|| {
     if let Ok(repo) = Repository::open(".") {

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -438,7 +438,7 @@ impl TryFrom<&Repository> for Settings {
     fn try_from(repo: &Repository) -> Result<Self, Self::Error> {
         match repo.get_repo_dir() {
             Some(repo_path) => {
-                let settings_path = repo_path.join(CONFIG_PATH);
+                let settings_path = repo_path.join((*CONFIG_PATH).as_str());
                 if settings_path.exists() {
                     Config::builder()
                         .add_source(File::from(settings_path))

--- a/tests/cog_tests/init.rs
+++ b/tests/cog_tests/init.rs
@@ -44,7 +44,7 @@ fn init_existing_repo() -> Result<()> {
 fn fail_if_config_exist() -> Result<()> {
     // Arrange
     git_init_and_set_current_path("test_repo_existing")?;
-    std::fs::write(PathBuf::from_str(CONFIG_PATH)?, "[hooks]")?;
+    std::fs::write(PathBuf::from_str((*CONFIG_PATH).as_ref())?, "[hooks]")?;
     git_commit("chore: test commit")?;
 
     // Act

--- a/tests/helpers.rs
+++ b/tests/helpers.rs
@@ -143,6 +143,6 @@ pub fn git_log_head() -> Result<String> {
 
 /// Create an empty `cog.toml` config file in the current directory
 pub fn create_empty_config() -> Result<()> {
-    std::fs::File::create(CONFIG_PATH)?;
+    std::fs::File::create(CONFIG_PATH.as_str())?;
     Ok(())
 }


### PR DESCRIPTION
This PRs brings the ability to define `cog.toml` file path through `COG_CONFIG_PATH` environment variable (related to #343).

The issue was first proposing to add an argument to the CLI but with the actual architecture this goal would require lots of changes in the code.

If `COG_CONFIG_PATH ` is not specified, the previous value (*i.e.* `cog.toml`) will be used.