### PR TITLE
docs(commits-types): bump minor and patch options

### DIFF
--- a/docs/website/config/README.md
+++ b/docs/website/config/README.md
@@ -83,6 +83,29 @@ The config reference list all value that can be set in the `cog.toml` file at th
     [commit_types]
     chore = { changelog_title = "Chore", omit_from_changelog = true }
     ```
+
+### `bump_patch`
+- Type: `Bool`
+- Optional: `true`
+- Default value: `false`
+- Description: commits of this type will bump the patch version of a tag.
+- Example:
+    ```toml
+    [commit_types]
+    chore = { changelog_title = "Chore", bump_patch = true }
+    ```
+
+### `bump_minor`
+- Type: `Bool`
+- Optional: `true`
+- Default value: `false`
+- Description: commits of this type will bump the minor version of a tag.
+- Example:
+    ```toml
+    [commit_types]
+    chore = { changelog_title = "Chore", bump_minor = true }
+    ```
+
 ## Bump config
 
 ### `pre_bump_hooks`


### PR DESCRIPTION
Remembered seeing this in the commits but couldn't find it in the docs :D