### PR TITLE
feat(check): Support commit scope checking

### DIFF
--- a/src/conventional/commit.rs
+++ b/src/conventional/commit.rs
@@ -82,6 +82,19 @@ impl Commit {
                     date,
                 };
 
+                if let (Some(scopes), Some(scope)) =
+                    (&SETTINGS.commit_scopes(), &commit.conventional.scope)
+                {
+                    if !scopes.contains(scope) {
+                        return Err(Box::new(ConventionalCommitError::CommitScopeNotDefined {
+                            oid: commit.oid.to_string(),
+                            summary: format_summary(&commit.conventional),
+                            scope: scope.to_string(),
+                            author: commit.author,
+                        }));
+                    }
+                }
+
                 match &SETTINGS
                     .commit_types()
                     .get(&commit.conventional.commit_type)

--- a/src/conventional/error.rs
+++ b/src/conventional/error.rs
@@ -20,6 +20,12 @@ pub enum ConventionalCommitError {
         commit_type: String,
         author: String,
     },
+    CommitScopeNotDefined {
+        oid: String,
+        summary: String,
+        scope: String,
+        author: String,
+    },
     ParseError(ParseError),
 }
 
@@ -124,6 +130,26 @@ impl Display for ConventionalCommitError {
                     cause = "Error:".yellow().bold(),
                     summary = summary.italic(),
                     commit_type = commit_type.red()
+                )
+            }
+            ConventionalCommitError::CommitScopeNotDefined {
+                oid,
+                summary,
+                scope,
+                author,
+            } => {
+                let error_header = "Errored commit: ".bold().red();
+                let author = format!("<{author}>").blue();
+                writeln!(
+                    f,
+                    "{}{} {}\n\t{message}'{summary}'\n\t{cause}Commit scope `{scope}` not allowed",
+                    error_header,
+                    oid,
+                    author,
+                    message = "Commit message:".yellow().bold(),
+                    cause = "Error: ".yellow().bold(),
+                    summary = summary.italic(),
+                    scope = scope.red(),
                 )
             }
             ConventionalCommitError::ParseError(err) => {

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -68,6 +68,7 @@ pub struct Settings {
     pub changelog: Changelog,
     pub bump_profiles: HashMap<String, BumpProfile>,
     pub packages: HashMap<String, MonoRepoPackage>,
+    pub scopes: Option<Vec<String>>,
 }
 
 impl Default for Settings {
@@ -94,6 +95,7 @@ impl Default for Settings {
             changelog: Default::default(),
             bump_profiles: Default::default(),
             packages: Default::default(),
+            scopes: Default::default(),
         }
     }
 }
@@ -350,6 +352,10 @@ impl Settings {
                 CommitConfigOrNull::None {} => None,
             })
             .collect()
+    }
+
+    pub fn commit_scopes(&self) -> Option<Vec<String>> {
+        self.scopes.clone()
     }
 
     fn default_commit_config() -> CommitsMetadata {


### PR DESCRIPTION
Personally, I'm missing this feature. I realise that, ideally, suggestions for scopes are desirable (as written in #42) but having this feature in cocogitto without suggestions is a great improvement already, especially for CI.

The tests fail for me with these changes but I can't figure out why. Some pointers would be appreciated here! Besides the failing tests this is done :)