### PR TITLE
feat: add build version to command

### DIFF
--- a/docs/website/guide/README.md
+++ b/docs/website/guide/README.md
@@ -603,11 +603,12 @@ Cocogitto let you specify the target version with the following flags :
 - `--patch` : increment the PATCH version.
 - `--version <version>` : set version manually ( ex : `cog bump --version 3.2.1`).
 - `--pre <metadata>` : set the [pre-release metatada](https://semver.org/#spec-item-9).
+- `--build <metadata>` : set the [build metatada](https://semver.org/#spec-item-10).
 
 **Example:**
 ```bash
-cog bump --major --pre "beta.1"
-# 1.2.3 -> 2.0.0-beta.1
+cog bump --major --pre "beta.1" --build "foo.bar"
+# 1.2.3 -> 2.0.0-beta.1+foo.bar
 ```
 :::
 

--- a/src/bin/cog/main.rs
+++ b/src/bin/cog/main.rs
@@ -267,6 +267,10 @@ enum Command {
         #[arg(long)]
         pre: Option<String>,
 
+        /// Set the build suffix
+        #[arg(long)]
+        build: Option<String>,
+
         /// Specify the bump profile hooks to run
         #[arg(short = 'H', long, value_parser = hook_profiles())]
         hook_profile: Option<String>,
@@ -390,6 +394,7 @@ fn main() -> Result<()> {
             minor,
             patch,
             pre,
+            build,
             hook_profile,
             package,
             annotated,
@@ -431,6 +436,7 @@ fn main() -> Result<()> {
                             package,
                             increment,
                             pre_release: pre.as_deref(),
+                            build: build.as_deref(),
                             hooks_config: hook_profile.as_deref(),
                             annotated,
                             dry_run,
@@ -446,6 +452,7 @@ fn main() -> Result<()> {
                         let opts = BumpOptions {
                             increment,
                             pre_release: pre.as_deref(),
+                            build: build.as_deref(),
                             hooks_config: hook_profile.as_deref(),
                             annotated,
                             dry_run,
@@ -462,6 +469,7 @@ fn main() -> Result<()> {
                 let opts = BumpOptions {
                     increment,
                     pre_release: pre.as_deref(),
+                    build: build.as_deref(),
                     hooks_config: hook_profile.as_deref(),
                     annotated,
                     dry_run,

--- a/src/command/bump/mod.rs
+++ b/src/command/bump/mod.rs
@@ -29,6 +29,7 @@ mod standard;
 pub struct BumpOptions<'a> {
     pub increment: IncrementCommand,
     pub pre_release: Option<&'a str>,
+    pub build: Option<&'a str>,
     pub hooks_config: Option<&'a str>,
     pub annotated: Option<String>,
     pub dry_run: bool,
@@ -44,6 +45,7 @@ pub struct PackageBumpOptions<'a> {
     pub package: &'a MonoRepoPackage,
     pub increment: IncrementCommand,
     pub pre_release: Option<&'a str>,
+    pub build: Option<&'a str>,
     pub hooks_config: Option<&'a str>,
     pub annotated: Option<String>,
     pub dry_run: bool,

--- a/src/command/bump/package.rs
+++ b/src/command/bump/package.rs
@@ -10,7 +10,7 @@ use crate::{CocoGitto, SETTINGS};
 use anyhow::Result;
 use colored::*;
 use log::info;
-use semver::{Prerelease, BuildMetadata};
+use semver::{BuildMetadata, Prerelease};
 use tera::Tera;
 
 impl CocoGitto {
@@ -34,7 +34,7 @@ impl CocoGitto {
         }
 
         if let Some(build) = opts.build {
-            tag.version.build = BuildMetadata::new(build)?;
+            next_version.version.build = BuildMetadata::new(build)?;
         }
 
         let tag = Tag::create(

--- a/src/command/bump/package.rs
+++ b/src/command/bump/package.rs
@@ -10,7 +10,7 @@ use crate::{CocoGitto, SETTINGS};
 use anyhow::Result;
 use colored::*;
 use log::info;
-use semver::Prerelease;
+use semver::{Prerelease, BuildMetadata};
 use tera::Tera;
 
 impl CocoGitto {
@@ -31,6 +31,10 @@ impl CocoGitto {
 
         if let Some(pre_release) = opts.pre_release {
             next_version.version.pre = Prerelease::new(pre_release)?;
+        }
+
+        if let Some(build) = opts.build {
+            tag.version.build = BuildMetadata::new(build)?;
         }
 
         let tag = Tag::create(

--- a/src/command/bump/standard.rs
+++ b/src/command/bump/standard.rs
@@ -10,7 +10,7 @@ use crate::{settings, CocoGitto, SETTINGS};
 use anyhow::Result;
 use colored::*;
 use log::info;
-use semver::{Prerelease, BuildMetadata};
+use semver::{BuildMetadata, Prerelease};
 use tera::Tera;
 
 impl CocoGitto {

--- a/src/command/bump/standard.rs
+++ b/src/command/bump/standard.rs
@@ -10,7 +10,7 @@ use crate::{settings, CocoGitto, SETTINGS};
 use anyhow::Result;
 use colored::*;
 use log::info;
-use semver::Prerelease;
+use semver::{Prerelease, BuildMetadata};
 use tera::Tera;
 
 impl CocoGitto {
@@ -29,6 +29,10 @@ impl CocoGitto {
 
         if let Some(pre_release) = opts.pre_release {
             tag.version.pre = Prerelease::new(pre_release)?;
+        }
+
+        if let Some(build) = opts.build {
+            tag.version.build = BuildMetadata::new(build)?;
         }
 
         let tag = Tag::create(tag.version, None);

--- a/tests/cog_tests/bump.rs
+++ b/tests/cog_tests/bump.rs
@@ -299,6 +299,26 @@ fn pre_release_bump() -> Result<()> {
 }
 
 #[sealed_test]
+fn build_release_bump() -> Result<()> {
+    git_init()?;
+    git_commit("chore: init")?;
+    git_tag("1.0.0")?;
+    git_commit("feat: feature")?;
+
+    Command::cargo_bin("cog")?
+        .arg("bump")
+        .arg("--major")
+        .arg("--build")
+        .arg("a.b.c")
+        .assert()
+        .success();
+
+    assert_that!(Path::new("CHANGELOG.md")).exists();
+    assert_tag_exists("2.0.0+a.b.c")?;
+    Ok(())
+}
+
+#[sealed_test]
 #[cfg(target_os = "linux")]
 fn bump_with_hook() -> Result<()> {
     // Arrange


### PR DESCRIPTION
# Context

- Soft-Fork a project
- Make private releases with added functionality
- Create a private release while honoring upstream SemVer
- That's what `build` ~~is~~ can be used for

# Proposed Solution

- Add `--build foo.bar.bui` to the `cog bump` command
