### PR TITLE
feat: Make version DSL tags nullable - #363

### DIFF
--- a/docs/website/guide/README.md
+++ b/docs/website/guide/README.md
@@ -730,17 +730,18 @@ A typical example in the java world would be to bump your maven snapshot on your
 # cog.toml
 post_bump_hooks = [
     "git push",
-    "git push origin {{version}}",
+    "git push origin {{version|1.0.0}}",
     "git checkout develop",
     "git rebase master",
-    "mvn versions:set -DnewVersion={{version+minor-SNAPSHOT}}",
-    "cog commit chore \"bump snapshot to {{version+1minor-SNAPSHOT}}\"",
+    "mvn versions:set -DnewVersion={{version|1.0.0+minor-SNAPSHOT}}",
+    "cog commit chore \"bump snapshot to {{version|1.0.0+1minor-SNAPSHOT}}\"",
     "git push",
 ]
 ```
 
 As you can see we are bumping the manifest using a small DSL. It as only a few keywords :
 - start with the one of `version`,`version_tag`, `latest`, `latest_tag` or `package` keyword.
+- followed by the optional `|` operator and a default value (in SemVer format) in case the value for the keyword is not found.
 - followed by the `+` operator.
 - `major`, `minor` and `patch` to specify the kind of increment you want.
   Then an optional amount, default being one (`version+1minor` and `version+minor` being the same).

--- a/src/hook/version_dsl.pest
+++ b/src/hook/version_dsl.pest
@@ -34,10 +34,12 @@ identifiers = { identifier ~ (dot ~ identifier)* }
 pre_release = { pre_release_separator ~ identifiers }
 build_metadata = { build_metadata_separator ~ identifiers }
 
+default_separator = _{"|"}
+default_version = {  default_separator ~ identifiers }
 
 package = { "package" }
 version = { delimiter_start ~ (
-        ((current_tag | current_version | latest_tag | latest_version) ~ ops* ~ pre_release? ~ build_metadata?)
+        ((current_tag | current_version | latest_tag | latest_version) ~ default_version? ~ ops* ~ pre_release? ~ build_metadata?)
         | package
     ) ~ ( version_access_major | version_access_minor | version_access_patch )? ~ delimiter_end}
 version_dsl = { SOI ~ ( version | (!delimiter_start ~ ANY) )* ~ EOI }


### PR DESCRIPTION
Implementing #363:

Add optional default version definition in the VersionDSL, the separator is a `|`, the default version is defined in a way that allows us to apply modifiers to it when a version is not available. The same applies for tags (we use the tag prefix defined in the settings).

Hope the documentation is appropriate. 