### PR TITLE
docs: add json schema generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -430,6 +430,7 @@ dependencies = [
  "gix-discover",
  "log",
  "once_cell",
+ "schemars",
  "sealed_test",
  "serde",
  "speculoos",
@@ -483,6 +484,15 @@ dependencies = [
  "cocogitto-tag",
  "git2",
  "serde",
+]
+
+[[package]]
+name = "cocogitto-schema"
+version = "0.1.0"
+dependencies = [
+ "cocogitto-config",
+ "schemars",
+ "serde_json",
 ]
 
 [[package]]
@@ -679,6 +689,12 @@ name = "dunce"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
 
 [[package]]
 name = "edit"
@@ -1745,6 +1761,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.8.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0218ceea14babe24a4a5836f86ade86c1effbc198164e619194cb5069187e29"
+dependencies = [
+ "dyn-clone",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.8.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed5a1ccce8ff962e31a165d41f6e2a2dd1245099dc4d594f5574a86cd90f4d3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.63",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1795,6 +1835,17 @@ name = "serde_derive"
 version = "1.0.202"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6048858004bcff69094cd972ed40a32500f153bd3be9f716b2eed2e8217c4838"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.63",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ cocogitto-commit = { path = "crates/cocogitto-commit" }
 cocogitto-git = { path = "crates/cocogitto-git" }
 cocogitto-bump = { path = "crates/cocogitto-bump" }
 cocogitto-test-helpers = { path = "crates/cocogitto-test-helpers" }
+cocogitto-schema = { path = "crates/cocogitto-schema" }
 cocogitto = { path = "crates/cocogitto" }
 semver = "1.0.23"
 colored = "^2"
@@ -53,4 +54,3 @@ cmd_lib = "1.9.3"
 cargo_metadata = "0.18.1"
 pest = "2.7"
 pest_derive = "2.7"
-

--- a/cog.toml
+++ b/cog.toml
@@ -1,3 +1,5 @@
+#:schema ./docs/website/.vuepress/cog-schema.json
+
 # A list of glob patterns describing branches on which semver bump are allowed
 branch_whitelist = ["main"]
 
@@ -21,18 +23,16 @@ post_bump_hooks = [
     "git push",
     "git push origin {{version}}",
     "cargo package",
-    "cargo publish"
+    "cargo publish",
 ]
 
 # A custom named bump profile, the inner post/pre bump hook will be used
 # instead of the main ones when running `cog bump --hook-profile example --auto`
 [bump_profiles.example]
 pre_bump_hooks = [
-    "echo 'bumping from {{latest}} to {{version}} using a named profile'"
+    "echo 'bumping from {{latest}} to {{version}} using a named profile'",
 ]
-post_bump_hooks = [
-    "echo 'we are done'"
-]
+post_bump_hooks = ["echo 'we are done'"]
 
 # Shareable git-hooks, can be installed using `cog install-hook --all`
 # or alternatively `cog install-hooks {commit_hook_type}

--- a/crates/cocogitto-config/Cargo.toml
+++ b/crates/cocogitto-config/Cargo.toml
@@ -10,9 +10,13 @@ conventional_commit_parser.workspace = true
 once_cell.workspace = true
 gix-discover.workspace = true
 log.workspace = true
+schemars = { version = "0.8.20", optional = true }
 
 [dev-dependencies]
 speculoos.workspace = true
 sealed_test.workspace = true
 cocogitto-test-helpers.workspace = true
 anyhow.workspace = true
+
+[features]
+json_schema = ["schemars"]

--- a/crates/cocogitto-config/src/changelog.rs
+++ b/crates/cocogitto-config/src/changelog.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
 
+#[cfg_attr(feature = "json_schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Deserialize, Serialize, Clone, Eq, PartialEq)]
 #[serde(deny_unknown_fields, default)]
 pub struct Changelog {
@@ -28,6 +29,7 @@ impl Default for Changelog {
     }
 }
 
+#[cfg_attr(feature = "json_schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Deserialize, Serialize, Clone, Eq, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct AuthorSetting {

--- a/crates/cocogitto-config/src/commit.rs
+++ b/crates/cocogitto-config/src/commit.rs
@@ -3,6 +3,7 @@ use conventional_commit_parser::commit::CommitType;
 use serde::{Deserialize, Serialize};
 
 /// Configurations to create new conventional commit types or override behaviors of the existing ones.
+#[cfg_attr(feature = "json_schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Deserialize, Serialize, Clone, Eq, PartialEq)]
 pub struct CommitConfig {
     /// Define the title used in generated changelog for this commit type.

--- a/crates/cocogitto-config/src/git_hook.rs
+++ b/crates/cocogitto-config/src/git_hook.rs
@@ -5,6 +5,7 @@ use std::{
 
 use serde::{Deserialize, Serialize};
 
+#[cfg_attr(feature = "json_schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Deserialize, Serialize, Eq, PartialEq, Hash, Copy, Clone)]
 #[serde(deny_unknown_fields, rename_all = "kebab-case", into = "&str")]
 pub enum GitHookType {
@@ -95,6 +96,7 @@ impl fmt::Display for GitHookType {
     }
 }
 
+#[cfg_attr(feature = "json_schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Deserialize, Serialize, Eq, PartialEq)]
 #[serde(deny_unknown_fields, untagged)]
 pub enum GitHook {

--- a/crates/cocogitto-config/src/lib.rs
+++ b/crates/cocogitto-config/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(missing_docs)]
+
 use std::collections::HashMap;
 use std::path::PathBuf;
 
@@ -49,6 +51,7 @@ pub static COMMITS_METADATA: Lazy<HashMap<CommitType, CommitConfig>> =
 
 pub type CommitsMetadata = HashMap<CommitType, CommitConfigOrNull>;
 
+#[cfg_attr(feature = "json_schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 #[serde(untagged)]
 pub enum CommitConfigOrNull {
@@ -56,6 +59,7 @@ pub enum CommitConfigOrNull {
     None {},
 }
 
+#[cfg_attr(feature = "json_schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Deserialize, Serialize, Eq, PartialEq)]
 #[serde(deny_unknown_fields, default)]
 pub struct Settings {
@@ -119,6 +123,7 @@ pub fn changelog_path() -> &'static PathBuf {
     &SETTINGS.changelog.path
 }
 
+#[cfg_attr(feature = "json_schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Deserialize, Serialize, Default, Eq, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct BumpProfile {

--- a/crates/cocogitto-config/src/monorepo.rs
+++ b/crates/cocogitto-config/src/monorepo.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::BumpProfile;
 
+#[cfg_attr(feature = "json_schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Deserialize, Serialize, Eq, PartialEq)]
 #[serde(deny_unknown_fields, default)]
 pub struct MonoRepoPackage {

--- a/crates/cocogitto-schema/Cargo.toml
+++ b/crates/cocogitto-schema/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "cocogitto-schema"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+cocogitto-config = { workspace = true, features = ["json_schema"] }
+schemars = "0.8.20"
+serde_json = "1.0.117"

--- a/crates/cocogitto-schema/src/main.rs
+++ b/crates/cocogitto-schema/src/main.rs
@@ -1,0 +1,14 @@
+use cocogitto_config::Settings;
+use schemars::schema_for;
+
+/**
+Prints the json schema of [Settings] to stdout
+## Example
+```bash
+cargo run > cog-schema.json
+```
+ */
+fn main() {
+    let schema = schema_for!(Settings);
+    println!("{}", serde_json::to_string_pretty(&schema).unwrap());
+}

--- a/crates/cocogitto/src/command/init.rs
+++ b/crates/cocogitto/src/command/init.rs
@@ -38,12 +38,16 @@ pub fn init<S: AsRef<Path> + ?Sized>(path: &S) -> anyhow::Result<()> {
         eprint!("Found {} in {:?}, Nothing to do", CONFIG_PATH, &path);
         exit(1);
     } else {
-        std::fs::write(
-            &settings_path,
-            toml::to_string(&settings)
-                .map_err(|err| anyhow!("failed to serialize {}\n\ncause: {}", CONFIG_PATH, err))?,
-        )
-        .map_err(|err| {
+        let toml_string = toml::to_string(&settings)
+            .map(|toml_string| {
+                return format!(
+                    "{}\n\n{}",
+                    "#:schema https://docs.cocogitto.io/cog-schema.json", toml_string
+                );
+            })
+            .map_err(|err| anyhow!("failed to serialize {}\n\ncause: {}", CONFIG_PATH, err))?;
+
+        std::fs::write(&settings_path, toml_string).map_err(|err| {
             anyhow!(
                 "failed to write file `{:?}`\n\ncause: {}",
                 settings_path,

--- a/docs/website/.vuepress/public/cog-schema.json
+++ b/docs/website/.vuepress/public/cog-schema.json
@@ -1,0 +1,345 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Settings",
+  "type": "object",
+  "properties": {
+    "branch_whitelist": {
+      "default": [],
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "bump_profiles": {
+      "default": {},
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/BumpProfile"
+      }
+    },
+    "changelog": {
+      "default": {
+        "authors": [],
+        "owner": null,
+        "package_template": null,
+        "path": "CHANGELOG.md",
+        "remote": null,
+        "repository": null,
+        "template": null
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/Changelog"
+        }
+      ]
+    },
+    "commit_types": {
+      "default": {},
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/CommitConfigOrNull"
+      }
+    },
+    "disable_bump_commit": {
+      "default": false,
+      "type": "boolean"
+    },
+    "disable_changelog": {
+      "default": false,
+      "type": "boolean"
+    },
+    "from_latest_tag": {
+      "default": false,
+      "type": "boolean"
+    },
+    "generate_mono_repository_global_tag": {
+      "default": true,
+      "type": "boolean"
+    },
+    "git_hooks": {
+      "default": {},
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/GitHook"
+      }
+    },
+    "ignore_merge_commits": {
+      "default": false,
+      "type": "boolean"
+    },
+    "monorepo_version_separator": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "packages": {
+      "default": {},
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/MonoRepoPackage"
+      }
+    },
+    "post_bump_hooks": {
+      "default": [],
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "post_package_bump_hooks": {
+      "default": [],
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "pre_bump_hooks": {
+      "default": [],
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "pre_package_bump_hooks": {
+      "default": [],
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "skip_ci": {
+      "default": "[skip ci]",
+      "type": "string"
+    },
+    "skip_untracked": {
+      "default": false,
+      "type": "boolean"
+    },
+    "tag_prefix": {
+      "type": [
+        "string",
+        "null"
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "definitions": {
+    "AuthorSetting": {
+      "type": "object",
+      "required": [
+        "signature",
+        "username"
+      ],
+      "properties": {
+        "signature": {
+          "type": "string"
+        },
+        "username": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "BumpProfile": {
+      "type": "object",
+      "properties": {
+        "post_bump_hooks": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "pre_bump_hooks": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "Changelog": {
+      "type": "object",
+      "properties": {
+        "authors": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/AuthorSetting"
+          }
+        },
+        "owner": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "package_template": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "path": {
+          "default": "CHANGELOG.md",
+          "type": "string"
+        },
+        "remote": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "repository": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "template": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "CommitConfig": {
+      "description": "Configurations to create new conventional commit types or override behaviors of the existing ones.",
+      "type": "object",
+      "required": [
+        "changelog_title"
+      ],
+      "properties": {
+        "bump_minor": {
+          "description": "Allow for this commit type to bump the minor version.",
+          "default": false,
+          "type": "boolean"
+        },
+        "bump_patch": {
+          "description": "Allow for this commit type to bump the patch version.",
+          "default": false,
+          "type": "boolean"
+        },
+        "changelog_title": {
+          "description": "Define the title used in generated changelog for this commit type.",
+          "type": "string"
+        },
+        "omit_from_changelog": {
+          "description": "Do not display this commit type in changelogs.",
+          "default": false,
+          "type": "boolean"
+        }
+      }
+    },
+    "CommitConfigOrNull": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/CommitConfig"
+        },
+        {
+          "type": "object"
+        }
+      ]
+    },
+    "GitHook": {
+      "anyOf": [
+        {
+          "type": "object",
+          "required": [
+            "script"
+          ],
+          "properties": {
+            "script": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "path"
+          ],
+          "properties": {
+            "path": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "MonoRepoPackage": {
+      "type": "object",
+      "properties": {
+        "bump_profiles": {
+          "description": "Custom profile to override `pre_bump_hooks`, `post_bump_hooks`",
+          "default": {},
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/BumpProfile"
+          }
+        },
+        "changelog_path": {
+          "description": "Where to write the changelog",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "ignore": {
+          "description": "List of globs for paths to ignore, relative to the repository root dir.",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "include": {
+          "description": "List of globs for additional paths to include, relative to the repository root dir.",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "path": {
+          "description": "The package path, relative to the repository root dir. Used to scan commits and set hook commands current directory",
+          "default": "",
+          "type": "string"
+        },
+        "post_bump_hooks": {
+          "description": "Overrides `post_package_bump_hooks`",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "pre_bump_hooks": {
+          "description": "Overrides `pre_package_bump_hooks`",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_api": {
+          "description": "Bumping package marked as public api will increment the global monorepo once_celversion when using `cog bump --auto`",
+          "default": true,
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/justfile
+++ b/justfile
@@ -6,6 +6,9 @@ test:
     cargo install cargo-nextest
     cargo nextest run
 
+json-schema: 
+    cargo run -p cocogitto-schema > docs/website/.vuepress/public/cog-schema.json
+
 build-x86:
     cross build --target x86_64-unknown-linux-musl --release
     just clean-targets


### PR DESCRIPTION
Example of generating json docs from the `Settings` struct using the `JSONSchema` derive macro from [schemars](https://docs.rs/schemars/latest/schemars/). It just needs some entrypoint in the codebase where it can output the schema. This pull request uses a second `bin` called `schema` to do it. I don't know what's best practice. Another alternative would be to use `example` instead of `bin`.

This pull request tries to separate the schema building code by putting it under a separate feature flag `json_schema` so that the cog CLI isn't (potentially) affected.

How to generate:
```bash
cargo run --release --bin schema --features=json_schema > docs/website/.vuepress/public/cog-schema.json
```

What's missing:
- When to generate the json schema in the workflows
- Should json schema be versioned?
- Missing a lot of descriptions on fields that could get added layer to expose descriptions in the schema as well