### PR TITLE
docs(config): add link to cog.toml config reference to README and cog.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,12 @@ git commit -m "feat: add awesome feature"
 
 See [User guide -> Conventional commits](https://docs.cocogitto.io/guide/#conventional-commits).
 
+## Configuration
+
+Use `cog.toml` file to configure your usage of Cocogitto.
+
+For the full list of options, see [User guide ->  Configuration reference](https://docs.cocogitto.io/config/).
+
 ## Auto-bumps
 
 Creating a version with `cog bump` will perform the following actions :

--- a/cog.toml
+++ b/cog.toml
@@ -1,3 +1,5 @@
+# For a reference of possible values: https://docs.cocogitto.io/config/
+
 # A list of glob patterns describing branches on which semver bump are allowed
 branch_whitelist = ["main"]
 


### PR DESCRIPTION
Just to make it a little easier to find some basic docs. Thanks for the great documentation!