### PR TITLE
docs(website): include MacOS install instructions on homepage

### DIFF
--- a/docs/website/index.md
+++ b/docs/website/index.md
@@ -48,6 +48,12 @@ nix-env -iA nixos.cocogitto
 xbps-install cocogitto
 ```
 
+### MacOS
+
+```shell script
+brew install cocogitto
+```
+
 ## Shell completions
 
 Before getting started you might want to install shell completions (Note that this is not needed for the official archlinux package).


### PR DESCRIPTION
This PR will update the documentation website's homepage to include MacOS install instructions, which are already present in the repository's README.