### PR TITLE
bug(bump): Always output computed version

### DIFF
--- a/src/command/bump/standard.rs
+++ b/src/command/bump/standard.rs
@@ -20,7 +20,7 @@ impl CocoGitto {
         let current_tag = self.repository.get_latest_tag(TagLookUpOptions::default());
         let current_tag = tag_or_fallback_to_zero(current_tag)?;
         let mut tag = current_tag.bump(opts.increment, &self.repository)?;
-        if current_tag == tag {
+        if !opts.dry_run && current_tag == tag {
             print!("No conventional commits for your repository that required a bump. Changelogs will be updated on the next bump.\nPre-Hooks and Post-Hooks have been skipped.\n");
             return Ok(());
         }

--- a/tests/cog_tests/bump.rs
+++ b/tests/cog_tests/bump.rs
@@ -76,6 +76,27 @@ fn auto_bump_dry_run_from_latest_tag() -> Result<()> {
 }
 
 #[sealed_test]
+fn auto_no_bump_dry_run_from_latest_tag() -> Result<()> {
+    git_init()?;
+    git_commit("chore: init")?;
+    git_commit("feat(taef): feature")?;
+    let tag = "1.0.0";
+    git_tag(tag)?;
+    git_commit("chore(taef): boring")?;
+    git_commit("chore: boring 2")?;
+
+    Command::cargo_bin("cog")?
+        .arg("bump")
+        .arg("--auto")
+        .arg("--dry-run")
+        .assert()
+        .success()
+        .stdout(format!("{tag}\n"));
+
+    Ok(())
+}
+
+#[sealed_test]
 fn auto_bump_major_from_latest_tag() -> Result<()> {
     git_init()?;
     git_commit("chore: init")?;


### PR DESCRIPTION
`--dry-run` is often used in scripts that want the computed version. When commits between the previous and current contain no commit types that warrant a bump, the error message "No conventional commits for your repository that required a bump..." is printed, breaking scripts.

I'd understand if this behavior isn't desired as "dry run" implies that some warnings are expected if operations don't go as expected. It is mentioned in the documentation that:

>  The dry-run flag can be helpful when writing shell scritps using cocogitto. Since only the version number will output to stdout [...]

In a project my team is working on, this tripped us up as we are using this in a shell script and struggled to figure out why it wasn't bumping. Of course, it makes perfect sense now and the resulting version is valid. If however, the version is equal to the previous value, we would like it  to just output the version even if it hasn't changed. 