### PR TITLE
feat: open repo at path

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,12 +73,16 @@ pub enum CommitHook {
 }
 
 impl CocoGitto {
-    pub fn get() -> Result<Self> {
-        let repository = Repository::open(&std::env::current_dir()?)?;
+    pub fn get_at(path: PathBuf) -> Result<Self> {
+        let repository = Repository::open(&path)?;
         let _settings = Settings::get(&repository)?;
         let _changelog_path = settings::changelog_path();
 
         Ok(CocoGitto { repository })
+    }
+
+    pub fn get() -> Result<Self> {
+        CocoGitto::get_at(std::env::current_dir()?)
     }
 
     pub fn get_committer(&self) -> Result<String, Git2Error> {


### PR DESCRIPTION
Added a method to the CocoGitto implementation to allow for using CocoGitto at custom paths, not only the current working directory.
I need it in [cococonscious/koji](https://github.com/cococonscious/koji) for the git-like "-C" argument and integration tests.