### PR TITLE
fix(commit): fixed order of commit type options

### DIFF
--- a/src/bin/cog/commit.rs
+++ b/src/bin/cog/commit.rs
@@ -12,7 +12,8 @@ use itertools::Itertools;
 pub fn commit_types() -> PossibleValuesParser {
     let types = COMMITS_METADATA
         .iter()
-        .map(|(commit_type, _)| -> &str { commit_type.as_ref() });
+        .map(|(commit_type, _)| -> &str { commit_type.as_ref() })
+        .sorted();
 
     types.into()
 }


### PR DESCRIPTION
The order of commit type options in cog commit --help (and also in the manpage and shell completion) was random on each call. Use .sorted() to get a stable ordering and avoid confusion.

(I am not experienced with rust so if this is the wrong way please tell)