### PR TITLE
fix: set correct url for Getting Started

### DIFF
--- a/website/index.md
+++ b/website/index.md
@@ -11,7 +11,7 @@ hero:
   actions:
     - theme: brand
       text: Getting Started
-      link: /guide
+      link: /guide/init
 
 features:
   - title: Verified commits️


### PR DESCRIPTION
Previously Getting Started pointed to `/guide.html`:

![image](https://github.com/user-attachments/assets/e976faa2-2067-4efd-8672-6eb908da476d)

Which doesn't exist. The user guide is at `/guide/init.html`.