### PR TITLE
docs: fix capitalisation of NixOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ pacman -S cocogitto
 cargo install --locked cocogitto
 ```
 
-#### NixOs
+#### NixOS
 
 ```shell
 nix-env -iA cocogitto


### PR DESCRIPTION
Noticed the typo while reading the README.md, this PR fixes it.