### PR TITLE
Resolve tilde in the signingkey to home

### DIFF
--- a/src/git/commit.rs
+++ b/src/git/commit.rs
@@ -74,7 +74,7 @@ impl Repository {
             x509_gitsign(program, user, &commit_as_str)?
         } else {
             let program = self.gpg_program();
-            let key = self.signin_key().ok();
+            let key = self.signing_key().ok();
             gpg_sign_string(program, key, &commit_as_str)?
         };
 

--- a/src/git/commit.rs
+++ b/src/git/commit.rs
@@ -66,7 +66,7 @@ impl Repository {
 
         let signature = if self.ssh_sign() {
             let program = self.ssh_program();
-            let key = self.signin_key_path().ok();
+            let key = self.signing_key_path().ok();
             ssh_sign_string(program, key, &commit_as_str)?
         } else if self.x509_sign() {
             let program = self.gpg_x509_program();

--- a/src/git/commit.rs
+++ b/src/git/commit.rs
@@ -64,10 +64,9 @@ impl Repository {
             .expect("Invalid UTF-8 commit message")
             .to_string();
 
-        let key = self.signin_key().ok();
-
         let signature = if self.ssh_sign() {
             let program = self.ssh_program();
+            let key = self.signin_key_path().ok();
             ssh_sign_string(program, key, &commit_as_str)?
         } else if self.x509_sign() {
             let program = self.gpg_x509_program();
@@ -75,6 +74,7 @@ impl Repository {
             x509_gitsign(program, user, &commit_as_str)?
         } else {
             let program = self.gpg_program();
+            let key = self.signin_key().ok();
             gpg_sign_string(program, key, &commit_as_str)?
         };
 
@@ -154,16 +154,17 @@ fn gpg_sign_string(
 
 fn ssh_sign_string(
     program: String,
-    key: Option<String>,
+    key: Option<PathBuf>,
     content: &str,
 ) -> Result<String, Git2Error> {
     let Some(key) = key else {
         return Err(Git2Error::SshError("No ssh key found".to_string()));
     };
 
-    if !PathBuf::from(&key).exists() {
+    if !key.exists() {
         return Err(Git2Error::SshError(format!(
-            "Signing key not found in {key}"
+            "Signing key not found in {}",
+            key.display()
         )));
     }
 
@@ -173,7 +174,15 @@ fn ssh_sign_string(
     let buffer_file = buffer.to_string_lossy();
 
     Command::new(program)
-        .args(["-Y", "sign", "-n", "git", "-f", &key, buffer_file.as_ref()])
+        .args([
+            "-Y",
+            "sign",
+            "-n",
+            "git",
+            "-f",
+            key.to_string_lossy().as_ref(),
+            buffer_file.as_ref(),
+        ])
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::null())

--- a/src/git/repository.rs
+++ b/src/git/repository.rs
@@ -294,11 +294,11 @@ mod test {
             git config --local user.signingkey ~/.ssh/key.pub;
         )?;
 
-        let path_to_signing_key = repo.signing_key_path().ok();
-        let path_to_signing_key = path_to_signing_key.unwrap();
+        let path_to_signing_key = repo.signing_key_path().unwrap();
         let path_to_signing_key = path_to_signing_key.to_string_lossy();
 
-        let actual_home = std::env::var("HOME").ok().unwrap();
+        let home_env_var = if cfg!(windows) { "USERPROFILE" } else { "HOME" };
+        let actual_home = std::env::var(home_env_var).unwrap();
 
         assert_that!(path_to_signing_key).starts_with(actual_home);
 

--- a/src/git/repository.rs
+++ b/src/git/repository.rs
@@ -1,5 +1,8 @@
-use std::fmt::{Debug, Formatter};
 use std::path::Path;
+use std::{
+    fmt::{Debug, Formatter},
+    path::PathBuf,
+};
 
 use crate::git::error::Git2Error;
 use git2::{
@@ -12,6 +15,11 @@ impl Repository {
     pub(crate) fn signin_key(&self) -> Result<String, Git2Error> {
         let config = self.0.config()?;
         config.get_string("user.signingKey").map_err(Into::into)
+    }
+
+    pub(crate) fn signin_key_path(&self) -> Result<PathBuf, Git2Error> {
+        let config = self.0.config()?;
+        config.get_path("user.signingKey").map_err(Into::into)
     }
 
     pub(crate) fn gpg_sign(&self) -> bool {

--- a/src/git/repository.rs
+++ b/src/git/repository.rs
@@ -12,7 +12,7 @@ use git2::{
 pub(crate) struct Repository(pub(crate) Git2Repository);
 
 impl Repository {
-    pub(crate) fn signin_key(&self) -> Result<String, Git2Error> {
+    pub(crate) fn signing_key(&self) -> Result<String, Git2Error> {
         let config = self.0.config()?;
         config.get_string("user.signingKey").map_err(Into::into)
     }

--- a/src/git/repository.rs
+++ b/src/git/repository.rs
@@ -295,12 +295,11 @@ mod test {
         )?;
 
         let path_to_signing_key = repo.signing_key_path().unwrap();
-        let path_to_signing_key = path_to_signing_key.to_string_lossy();
 
         let home_env_var = if cfg!(windows) { "USERPROFILE" } else { "HOME" };
         let actual_home = std::env::var(home_env_var).unwrap();
 
-        assert_that!(path_to_signing_key).starts_with(actual_home);
+        assert!(path_to_signing_key.starts_with(actual_home));
 
         Ok(())
     }


### PR DESCRIPTION
Resolve a signingkey of `~/.ssh/key.pub` to `/home/kristof/.ssh/key.pub` using `git2`.

Test written to validate behavior on Linux & Windows.

Note that there are other variables being read that I haven't updated, but could benefit from reading the variable as a `PathBuf` and not a `&str`.

Happy to take this up in a future PR.