### PR TITLE
feat: allow specifying config path via command line

### DIFF
--- a/src/command/init.rs
+++ b/src/command/init.rs
@@ -1,6 +1,6 @@
+use crate::get_config_path;
 use crate::git::repository::Repository;
 use crate::settings::Settings;
-use crate::CONFIG_PATH;
 use anyhow::anyhow;
 use log::info;
 use std::path::Path;
@@ -34,15 +34,20 @@ pub fn init<S: AsRef<Path> + ?Sized>(path: &S) -> anyhow::Result<()> {
     };
 
     let settings = Settings::default();
-    let settings_path = path.join(CONFIG_PATH);
+    let settings_path = path.join(get_config_path());
     if settings_path.exists() {
-        eprint!("Found {} in {:?}, Nothing to do", CONFIG_PATH, &path);
+        eprint!("Found {} in {:?}, Nothing to do", get_config_path(), &path);
         exit(1);
     } else {
         std::fs::write(
             &settings_path,
-            toml::to_string(&settings)
-                .map_err(|err| anyhow!("failed to serialize {}\n\ncause: {}", CONFIG_PATH, err))?,
+            toml::to_string(&settings).map_err(|err| {
+                anyhow!(
+                    "failed to serialize {}\n\ncause: {}",
+                    get_config_path(),
+                    err
+                )
+            })?,
         )
         .map_err(|err| {
             anyhow!(

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 
 use crate::conventional::commit::CommitConfig;
 use crate::git::repository::Repository;
-use crate::{CONFIG_PATH, SETTINGS};
+use crate::{get_config_path, SETTINGS};
 
 use crate::conventional::changelog::error::ChangelogError;
 use crate::conventional::changelog::template::{RemoteContext, Template};
@@ -635,7 +635,7 @@ impl TryFrom<&Repository> for Settings {
     fn try_from(repo: &Repository) -> Result<Self, Self::Error> {
         match repo.get_repo_dir() {
             Some(repo_path) => {
-                let settings_path = repo_path.join(CONFIG_PATH);
+                let settings_path = repo_path.join(get_config_path());
                 if settings_path.exists() {
                     Config::builder()
                         .add_source(File::from(settings_path))

--- a/tests/cog_tests/init.rs
+++ b/tests/cog_tests/init.rs
@@ -2,7 +2,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::str::FromStr;
 
-use cocogitto::CONFIG_PATH;
+use cocogitto::DEFAULT_CONFIG_PATH;
 
 use crate::helpers::*;
 
@@ -44,7 +44,7 @@ fn init_existing_repo() -> Result<()> {
 fn fail_if_config_exist() -> Result<()> {
     // Arrange
     git_init_and_set_current_path("test_repo_existing")?;
-    std::fs::write(PathBuf::from_str(CONFIG_PATH)?, "[hooks]")?;
+    std::fs::write(PathBuf::from_str(DEFAULT_CONFIG_PATH)?, "[hooks]")?;
     git_commit("chore: test commit")?;
 
     // Act

--- a/tests/helpers.rs
+++ b/tests/helpers.rs
@@ -8,9 +8,9 @@ use speculoos::assert_that;
 use speculoos::iter::ContainingIntoIterAssertions;
 use speculoos::option::OptionAssertions;
 
+use cocogitto::get_config_path;
 use cocogitto::git::tag::Tag;
 use cocogitto::settings::{MonoRepoPackage, Settings};
-use cocogitto::CONFIG_PATH;
 
 pub fn init_monorepo(settings: &mut Settings) -> Result<()> {
     let mut packages = HashMap::new();
@@ -148,6 +148,6 @@ pub fn git_log_head_sha() -> Result<String> {
 
 /// Create an empty `cog.toml` config file in the current directory
 pub fn create_empty_config() -> Result<()> {
-    std::fs::File::create(CONFIG_PATH)?;
+    std::fs::File::create(get_config_path())?;
     Ok(())
 }

--- a/website/guide/misc.md
+++ b/website/guide/misc.md
@@ -120,3 +120,15 @@ Finally, if you need the command to print a version no matter the state of your 
 ❯ cog get-version --fallback 0.1.0
 0.1.0
 ```
+
+## Change path to config file
+
+By default, cocogitto uses the `cog.toml` file in a repo. Alternatively you can use `--config` to specify a path to the
+config file it should use.
+This allows you to move your config file wherever you want and specify an absolute path to it.
+
+For example to create a wrapper using Nix:
+
+```sh
+cocogitto --config /nix/store/...-cocogitto.toml $@
+```


### PR DESCRIPTION
This adds a cli flag "--config" which allows overriding which config file is used.
It's a bit hacky since the main clap CLI loads the config to show the possible values, but after some testing I think it works reliably. Defaulted it to `cog.toml` for tests, should be fine, right?

Supersedes #344 and fixes #343