### PR TITLE
fix: set explicit binstall pkg-url, bin-dir and pkg-fmt

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,3 +82,8 @@ required-features = ["docgen"]
 [[test]]
 name = "all"
 path = "tests/common.rs"
+
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/{ version }/{ name }-{ version }-{ target }.tar.gz"
+bin-dir = "{ target }/{ bin }{ binary-ext }"
+pkg-fmt = "tgz"


### PR DESCRIPTION
This PR explicitly configures `cargo-binstall` where to find the `cocogitto` artifacts, removing the need to iterate over n formats, reducing the amount of HTTP lookups, and reducing the risk of a 403.

Why you ask? It works at the moment? 

Well... kinda. 

The problem is that when you do `cargo binstall cocogitto`, `cargo-binstall` tries many different patterns: https://github.com/cargo-bins/cargo-binstall/blob/a90dd4569f858e438f8234fd24289093943dbd5a/SUPPORT.md#defaults

Doing that many tries for all the format in GitHub Actions results in the occasional 403 (make sure to scroll to the right -->):

```
cargo binstall --no-confirm cocogitto
  shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
  env:
    CARGO_TERM_COLOR: always
 INFO resolve: Resolving package: 'cocogitto'
 INFO has_release_artifact{release=GhRelease { repo: GhRepo { owner: "cocogitto", repo: "cocogitto" }, tag: "v6.3.0" } artifact_name="cocogitto-x86_64-unknown-linux-gnu-v6.3.0.tar"}:do_send_request{request=Request { method: GET, url: Url { scheme: "https", cannot_be_a_base: false, username: "", password: None, host: Some(Domain("api.github.com")), port: None, path: "/repos/cocogitto/cocogitto/releases/tags/v6.3.0", query: None, fragment: None }, headers: {"accept": "application/vnd.github+json", "x-github-api-version": "2022-11-28"} } url=https://api.github.com/repos/cocogitto/cocogitto/releases/tags/v6.3.0}: Received status code 403 Forbidden, will wait for 120s and retry
 INFO has_release_artifact{release=GhRelease { repo: GhRepo { owner: "cocogitto", repo: "cocogitto" }, tag: "6.3.0" } artifact_name="cocogitto-x86_64-unknown-linux-gnu-v6.3.0.tbz2"}:do_send_request{request=Request { method: GET, url: Url { scheme: "https", cannot_be_a_base: false, username: "", password: None, host: Some(Domain("api.github.com")), port: None, path: "/repos/cocogitto/cocogitto/releases/tags/6.3.0", query: None, fragment: None }, headers: {"accept": "application/vnd.github+json", "x-github-api-version": "2022-11-28"} } url=https://api.github.com/repos/cocogitto/cocogitto/releases/tags/6.3.0}: Received status code 403 Forbidden, will wait for 120s and retry
 WARN resolve: Timeout reached while checking fetcher invalid url: deadline has elapsed
 WARN resolve: Timeout reached while checking fetcher invalid url: deadline has elapsed
 WARN resolve: Timeout reached while checking fetcher QuickInstall: deadline has elapsed
 WARN resolve: Timeout reached while checking fetcher QuickInstall: deadline has elapsed
 WARN The package cocogitto v6.3.0 will be installed from source (with cargo)
    Updating crates.io index
 Downloading crates ...
  Downloaded cocogitto v6.3.0
  Installing cocogitto v6.3.0
    Updating crates.io index
     Locking 210 packages to latest compatible versions
      Adding colored v2.2.0 (available: v3.0.0)
      Adding config v0.14.1 (available: v0.15.13)
      Adding termcolor v1.1.3 (available: v1.4.1)
      Adding toml v0.8.23 (available: v0.9.2)
      Adding which v6.0.3 (available: v8.0.0)
 Downloading crates ...
  Downloaded chrono-tz-build v0.3.0
  Downloaded stable_deref_trait v1.2.0
  Downloaded block-buffer v0.10.4
  Downloaded autocfg v1.5.0
  Downloaded clap_complete v4.5.55
  Downloaded bitflags v2.9.1
  Downloaded fastrand v2.3.0
  Downloaded chrono v0.4.41
  Downloaded toml_write v0.1.2
  Downloaded zerofrom v0.1.6
  Downloaded clap_complete_nushell v4.5.8
  Downloaded conventional_commit_parser v0.9.4
  Downloaded unic-ucd-version v0.9.0
  Downloaded yoke-derive v0.8.0
  Downloaded zerovec-derive v0.11.1

...
```