### PR TITLE
Add ability to choose config path via COCOGITTO_CONFIG_PATH

### DIFF
--- a/src/config_path_test.rs
+++ b/src/config_path_test.rs
@@ -1,0 +1,33 @@
+#[cfg(test)]
+mod tests {
+    use std::env;
+    use crate::{get_config_path, DEFAULT_CONFIG_PATH};
+
+    #[test]
+    fn test_get_config_path_default() {
+        // Убедимся, что переменная окружения не установлена
+        env::remove_var("COCOGITTO_CONFIG_PATH");
+
+        // Получаем путь к конфигурационному файлу
+        let config_path = get_config_path();
+
+        // Проверяем, что возвращается путь по умолчанию
+        assert_eq!(config_path, DEFAULT_CONFIG_PATH);
+    }
+
+    #[test]
+    fn test_get_config_path_from_env() {
+        // Устанавливаем переменную окружения
+        let custom_path = "/custom/path/to/config.toml";
+        env::set_var("COCOGITTO_CONFIG_PATH", custom_path);
+
+        // Получаем путь к конфигурационному файлу
+        let config_path = get_config_path();
+
+        // Проверяем, что возвращается путь из переменной окружения
+        assert_eq!(config_path, custom_path);
+
+        // Очищаем переменную окружения
+        env::remove_var("COCOGITTO_CONFIG_PATH");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,9 +37,15 @@ static CONFIG_PATH: OnceLock<String> = OnceLock::new();
 
 pub fn get_config_path() -> &'static String {
     if cfg!(test) || std::env::var("RUSTY_FORK_OCCURS").is_ok() {
-        CONFIG_PATH.get_or_init(|| DEFAULT_CONFIG_PATH.to_owned())
+        CONFIG_PATH.get_or_init(|| {
+            std::env::var("COCOGITTO_CONFIG_PATH")
+                .unwrap_or_else(|_| DEFAULT_CONFIG_PATH.to_owned())
+        })
     } else {
-        CONFIG_PATH.get().expect("config path to be set")
+        CONFIG_PATH.get_or_init(|| {
+            std::env::var("COCOGITTO_CONFIG_PATH")
+                .unwrap_or_else(|_| DEFAULT_CONFIG_PATH.to_owned())
+        })
     }
 }
 


### PR DESCRIPTION
We are using common CI step that can be included to our CI for many repos.
So we need to have custom config for different projects.