### PR TITLE
Feat: add options to cog get-version

### DIFF
--- a/src/bin/cog/main.rs
+++ b/src/bin/cog/main.rs
@@ -252,6 +252,14 @@ enum Command {
         /// Specify which package to get the version for in a monorepo.
         #[arg(long, value_parser = packages())]
         package: Option<String>,
+
+        /// Include prerelease versions
+        #[arg(short, long)]
+        include_prereleases: bool,
+
+        /// Print full tag
+        #[arg(short, long)]
+        tag: bool,
     },
 
     /// Commit changelog from latest tag to HEAD and create new tag
@@ -418,9 +426,14 @@ fn main() -> Result<()> {
     init_logs(cli.verbose, cli.quiet);
 
     match cli.command {
-        Command::GetVersion { fallback, package } => {
+        Command::GetVersion {
+            fallback,
+            package,
+            include_prereleases,
+            tag,
+        } => {
             let cocogitto = CocoGitto::get()?;
-            cocogitto.get_latest_version(fallback, package)?
+            cocogitto.get_latest_version(fallback, package, include_prereleases, tag)?
         }
         Command::Bump {
             version,

--- a/tests/cog_tests/get_version.rs
+++ b/tests/cog_tests/get_version.rs
@@ -229,3 +229,48 @@ fn get_version_of_monorepo_package_having_own_version_ok() -> Result<()> {
 
     Ok(())
 }
+
+#[sealed_test]
+fn get_version_with_prereleases() -> Result<()> {
+    // Arrange
+    git_init()?;
+    git_commit("chore(version): 0.1.0")?;
+    git_tag("0.1.0")?;
+    git_commit("chore(version): 1.0.0-alpha.1")?;
+    git_tag("1.0.0-alpha.1")?;
+
+    // Act
+    let full_version = Command::cargo_bin("cog")?.arg("get-version").assert();
+    let prerelease = Command::cargo_bin("cog")?
+        .arg("get-version")
+        .arg("--include-prereleases")
+        .assert();
+
+    // Assert
+    full_version.success().stdout("0.1.0\n");
+    prerelease.success().stdout("1.0.0-alpha.1\n");
+
+    Ok(())
+}
+
+#[sealed_test]
+fn get_version_with_tag_prefix() -> Result<()> {
+    // Arrange
+    git_init()?;
+    git_add("tag_prefix = \"v\"", "cog.toml")?;
+    git_commit("feat: initial")?;
+    git_tag("v0.1.0")?;
+
+    // Act
+    let version = Command::cargo_bin("cog")?.arg("get-version").assert();
+    let tag = Command::cargo_bin("cog")?
+        .arg("get-version")
+        .arg("--tag")
+        .assert();
+
+    // Arrange
+    version.success().stdout("0.1.0\n");
+    tag.success().stdout("v0.1.0\n");
+
+    Ok(())
+}

--- a/website/guide/misc.md
+++ b/website/guide/misc.md
@@ -100,7 +100,7 @@ Current version:
 5.3.1
 ```
 
-To silence the additional info and get only the version use the `-v` flag:
+To silence the additional info and get only the version use the `-v` flag (note that the flag is before `get-version`):
 
 ```bash
 ❯ cog -v get-version
@@ -110,15 +110,33 @@ To silence the additional info and get only the version use the `-v` flag:
 If working on a monorepo you can also specify the target package:
 
 ```bash
-❯ cog -v get-version --package gill-db
+❯ cog get-version --package gill-db
+Current version:
 0.1.0
 ```
 
-Finally, if you need the command to print a version no matter the state of your repository, you can provide a fallback:
+If you need the command to print a version no matter the state of your repository, you can provide a fallback:
 
 ```bash
 ❯ cog get-version --fallback 0.1.0
+Current version:
 0.1.0
+```
+
+To include prerelease versions, use the `--include-prereleases` flag:
+
+```bash
+❯ cog get-version --include-prereleases
+Current version:
+0.2.0-alpha.1
+```
+
+To print the full tag name, use the `--tag` flag:
+
+```bash
+❯ cog get-version --tag
+Current version:
+v0.1.0
 ```
 
 ## Change path to config file


### PR DESCRIPTION
This adds two options to `cog get-version`:
- `--include-prerelease` to include prerelease versions
- `--tag` to print full tag (including package + tag prefix)