### PR TITLE
[Draft] Add internal git commit template reader (help needed)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -318,6 +318,7 @@ dependencies = [
  "serde",
  "serde_json",
  "shell-words",
+ "shellexpand",
  "speculoos",
  "stderrlog",
  "tempfile",
@@ -465,6 +466,27 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+]
+
+[[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -943,6 +965,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
+name = "libredox"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
+dependencies = [
+ "bitflags 2.9.4",
+ "libc",
+]
+
+[[package]]
 name = "libz-sys"
 version = "1.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1096,6 +1128,12 @@ name = "once_cell_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "os_pipe"
@@ -1356,6 +1394,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.16",
+ "libredox",
+ "thiserror",
+]
+
+[[package]]
 name = "ref-cast"
 version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1578,6 +1627,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
 
 [[package]]
+name = "shellexpand"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1fdf65dd6331831494dd616b30351c38e96e45921a27745cf98490458b90bb"
+dependencies = [
+ "dirs",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1710,6 +1768,26 @@ name = "termtree"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "thread_local"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ cog_schemars = { version = "0.1.0", optional = true }
 serde_json = { version = "1.0.132", optional = true }
 maplit = "1.0.2"
 indexmap = { version = "2.11.4", features = ["serde"] }
+shellexpand = "3.1.1"
 
 [dev-dependencies]
 assert_cmd = "2.1.1"

--- a/src/bin/cog/commit.rs
+++ b/src/bin/cog/commit.rs
@@ -76,12 +76,15 @@ pub fn edit_message<P: AsRef<Path>>(
     ))
 }
 
-const EDIT_TEMPLATE: &str = "# Enter the commit message for your changes.
+const PRE_HEADER_DEFAULT: &str = "# Enter the commit message for your changes.
 # Lines starting with # will be ignored, and empty body/footer are allowed.
 # Once you are done, save the changes and exit the editor.
 # Remove all non-comment lines to abort.
 #
 ";
+const BREAKING_WARNING_LINE: &str = "\n# WARNING: This will be marked as a breaking change!";
+const PRE_BODY_DEFAULT: &str = "# Message body\n";
+const PRE_FOOTER_DEFAULT: &str = "# Message footer\n# For example, foo: bar\n";
 
 fn prepare_header(typ: &str, message: &str, scope: Option<&str>) -> String {
     let mut header = typ.to_string();
@@ -95,19 +98,162 @@ fn prepare_header(typ: &str, message: &str, scope: Option<&str>) -> String {
     header
 }
 
+fn try_load_git_template() -> Option<String> {
+    let git_config = git2::Config::open_default().ok()?;
+    let git_template_entry = git_config.get_entry("commit.template").ok()?;
+    let git_template_path = git_template_entry.value()?;
+    let git_normalized_template_path = shellexpand::tilde(git_template_path).to_string();
+
+    fs::read_to_string(git_normalized_template_path).ok()
+}
+
+fn parse_comments(git_template: Option<String>) -> (String, String, String) {
+    let template = git_template.unwrap_or_default();
+    let normalized = template.replace("\r\n", "\n").replace("\r", "\n");
+    let paragraphs: Vec<_> = normalized
+        .split("\n\n")
+        .map(|s| s.trim())
+        .filter(|s| !s.is_empty())
+        .collect();
+
+    match paragraphs.as_slice() {
+        [] => (
+            PRE_HEADER_DEFAULT.to_string(),
+            PRE_BODY_DEFAULT.to_string(),
+            PRE_FOOTER_DEFAULT.to_string(),
+        ),
+        [pre_header] => (pre_header.to_string(), String::new(), String::new()),
+        [pre_header, pre_body] => (pre_header.to_string(), pre_body.to_string(), String::new()),
+        [pre_header, pre_body @ .., pre_footer] => (
+            pre_header.to_string(),
+            pre_body.join("\n"),
+            pre_footer.to_string(),
+        ),
+    }
+}
+
 fn prepare_edit_template(typ: &str, message: &str, scope: Option<&str>, breaking: bool) -> String {
-    let mut template: String = EDIT_TEMPLATE.into();
+    let git_template = try_load_git_template();
+    let (mut template, pre_body, pre_footer) = parse_comments(git_template);
+
     let header = prepare_header(typ, message, scope);
 
     if breaking {
-        template.push_str("# WARNING: This will be marked as a breaking change!\n");
+        template.push_str(BREAKING_WARNING_LINE);
     }
 
     write!(
         &mut template,
-        "{header}\n\n# Message body\n\n\n# Message footer\n# For example, foo: bar\n\n\n"
+        "\n{header}\n\n{pre_body}\n\n{pre_footer}\n\n"
     )
     .unwrap();
 
     template
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use assert_cmd::{self, Command};
+    use cmd_lib::run_cmd;
+    use cocogitto::test_helpers;
+    use sealed_test::prelude::*;
+
+    #[test]
+    /// Defining scopes in cog.toml and using an undefined one should error.
+    fn test_parse_comments_none() {
+        let (h, b, f) = parse_comments(None);
+        assert_eq!(h, PRE_HEADER_DEFAULT, "Header comments must be default");
+        assert_eq!(b, PRE_BODY_DEFAULT, "Body comments must be default");
+        assert_eq!(f, PRE_FOOTER_DEFAULT, "Footer comments must be default");
+    }
+
+    #[test]
+    fn test_parse_comments_empty() {
+        let (h, b, f) = parse_comments(Some(String::new()));
+        assert_eq!(h, PRE_HEADER_DEFAULT, "Header comments must be default");
+        assert_eq!(b, PRE_BODY_DEFAULT, "Body comments must be default");
+        assert_eq!(f, PRE_FOOTER_DEFAULT, "Footer comments must be default");
+    }
+
+    #[test]
+    fn test_parse_comments_only_header() {
+        let template = "# Header\n\n";
+        let (h, b, f) = parse_comments(Some(String::from(template)));
+        assert_eq!(
+            h, "# Header",
+            "Header comments must be parsed from template"
+        );
+        assert_eq!(b, "", "Body comments must be empty");
+        assert_eq!(f, "", "Footer comments must be empty");
+    }
+
+    #[test]
+    fn test_parse_comments_header_and_body() {
+        let template = "# Header\n\n# Body\n\n";
+        let (h, b, f) = parse_comments(Some(String::from(template)));
+        assert_eq!(
+            h, "# Header",
+            "Header comments must be parsed from template"
+        );
+        assert_eq!(b, "# Body", "Body comments must be parsed from template");
+        assert_eq!(f, "", "Footer comments must be empty");
+    }
+
+    #[test]
+    fn test_parse_comments_all_parts() {
+        let template = "# Header\n\n# Body\n\n# Footer\n\n";
+        let (h, b, f) = parse_comments(Some(String::from(template)));
+        assert_eq!(
+            h, "# Header",
+            "Header comments must be parsed from template"
+        );
+        assert_eq!(b, "# Body", "Body comments must be parsed from template");
+        assert_eq!(
+            f, "# Footer",
+            "Footer comments must be parsed from template"
+        );
+    }
+
+    #[test]
+    fn test_parse_comments_multiple_body_parts() {
+        let template = "# Header\n\n# Body 1\n\n# Body 2\n\n# Footer\n\n";
+        let (h, b, f) = parse_comments(Some(String::from(template)));
+        assert_eq!(
+            h, "# Header",
+            "Header comments must be parsed from template"
+        );
+        assert_eq!(
+            b, "# Body 1\n# Body 2",
+            "Body multiple comments must be parsed from template and combined"
+        );
+        assert_eq!(
+            f, "# Footer",
+            "Footer comments must be parsed from template"
+        );
+    }
+
+    #[sealed_test]
+    fn test_try_load_git_template_not_setup() {
+        git_init()?;
+        let template = try_load_git_template();
+        assert_eq!(template, None, "Git template must be None");
+    }
+
+    #[sealed_test]
+    fn test_try_load_git_template_setup_but_no_file() {
+        git_init()?;
+        // run_cmd!(git config --local commit.tempalte "./template");
+        let template = try_load_git_template();
+        assert_eq!(template, None, "Git template setup, but can't read file");
+    }
+
+    #[sealed_test]
+    fn test_try_load_git_template_ok() {
+        git_init()?;
+        // run_cmd!(git config --local commit.tempalte "./template");
+        // fs:write("./template", "# Template file")?;
+        let template = try_load_git_template();
+        assert_eq!(template, Some("# Template file"), "Template file read ok");
+    }
 }


### PR DESCRIPTION
Issue: I’ve added an internal function to read/parse git commit templates in `cog`.  
Parsing logic is tested, but I can’t write tests for the file-reading step because the helper is not visible in the `tests` subcrate.  

Looking for advice on how to test internal file-system/git-config dependent logic properly.  
Parsing tests are included; stuck on testing the `test_try_load_git_template` part.