### PR TITLE
refactor: core types

### DIFF
--- a/crates/cocogitto/src/command/bump/mod.rs
+++ b/crates/cocogitto/src/command/bump/mod.rs
@@ -2,7 +2,7 @@ use crate::command::bump::prerelease::increment_prerelease;
 use crate::conventional::changelog::release::Release;
 use crate::conventional::commit::Commit;
 use crate::git::error::TagError;
-use crate::git::oid::OidOf;
+use crate::git::oid::ReleaseVersion;
 
 use crate::conventional::error::BumpError as ConvBumpError;
 use crate::conventional::version::IncrementCommand;
@@ -303,7 +303,7 @@ impl CocoGitto {
     pub fn get_changelog_with_target_version(&self, pattern: &str, tag: Tag) -> Result<Release> {
         let commit_range = self.repository.revwalk(pattern)?;
         let mut release = Release::try_from(commit_range)?;
-        release.version = OidOf::Tag(tag);
+        release.version = tag.into();
         Ok(release)
     }
 
@@ -318,8 +318,8 @@ impl CocoGitto {
             .repository
             .get_commit_range_for_package(pattern, package)?;
 
-        let mut release = Release::try_from(commit_range)?;
-        release.version = OidOf::Tag(tag);
+        let mut release = Release::build_package(commit_range, package)?;
+        release.version = tag.into();
         Ok(release)
     }
 
@@ -327,7 +327,7 @@ impl CocoGitto {
     pub fn get_monorepo_global_changelog_for_version(
         &self,
         pattern: &str,
-        from: OidOf,
+        from: ReleaseVersion,
         tag: Tag,
     ) -> Result<Release> {
         let commit_range = self
@@ -336,11 +336,11 @@ impl CocoGitto {
 
         let release = match Release::try_from(commit_range) {
             Ok(mut release) => {
-                release.version = OidOf::Tag(tag);
+                release.version = tag.into();
                 release
             }
             Err(_) => Release {
-                version: OidOf::Tag(tag),
+                version: tag.into(),
                 from,
                 date: Default::default(),
                 commits: vec![],

--- a/crates/cocogitto/src/command/bump/mod.rs
+++ b/crates/cocogitto/src/command/bump/mod.rs
@@ -8,6 +8,7 @@ use crate::conventional::error::BumpError as ConvBumpError;
 use crate::conventional::version::IncrementCommand;
 use crate::conventional::version::PreCommand;
 use crate::git::repository::Repository;
+use crate::git::rev::revspec::RevSpecPattern2;
 use crate::git::tag::{Tag, TagLookUpOptions};
 use crate::hook::{Hook, HookVersion, Hooks};
 use crate::settings::{HookType, MonoRepoPackage, Settings};
@@ -229,11 +230,12 @@ impl<'a> HookRunOptions<'a> {
 }
 
 impl CocoGitto {
-    fn get_bump_revspec(&mut self, current_tag: &Tag) -> String {
+    fn get_bump_revspec(&mut self, current_tag: &Tag) -> RevSpecPattern2 {
         if current_tag.is_zero() {
-            "..".to_string()
+            RevSpecPattern2::full()
         } else {
-            format!("{current_tag}..")
+            // this function is always called with the latest tag, so it should always have a oid
+            RevSpecPattern2::from(*current_tag.oid_unchecked())
         }
     }
 
@@ -300,7 +302,11 @@ impl CocoGitto {
     }
 
     /// The target version is not created yet when generating the changelog.
-    pub fn get_changelog_with_target_version(&self, pattern: &str, tag: Tag) -> Result<Release> {
+    pub fn get_changelog_with_target_version(
+        &self,
+        pattern: RevSpecPattern2,
+        tag: Tag,
+    ) -> Result<Release> {
         let commit_range = self.repository.revwalk(pattern)?;
         let mut release = Release::try_from(commit_range)?;
         release.version = tag.into();
@@ -310,7 +316,7 @@ impl CocoGitto {
     /// The target package version is not created yet when generating the changelog.
     pub fn get_package_changelog_with_target_version(
         &self,
-        pattern: &str,
+        pattern: RevSpecPattern2,
         tag: Tag,
         package: &str,
     ) -> Result<Release> {
@@ -326,7 +332,7 @@ impl CocoGitto {
     /// The target global monorepo version is not created yet when generating the changelog.
     pub fn get_monorepo_global_changelog_for_version(
         &self,
-        pattern: &str,
+        pattern: RevSpecPattern2,
         from: ReleaseVersion,
         tag: Tag,
     ) -> Result<Release> {

--- a/crates/cocogitto/src/command/bump/monorepo.rs
+++ b/crates/cocogitto/src/command/bump/monorepo.rs
@@ -186,7 +186,7 @@ impl CocoGitto {
         if !SETTINGS.disable_changelog {
             let pattern = self.get_bump_revspec(&bump_res.current);
             let changelog = self.get_monorepo_global_changelog_for_version(
-                &pattern,
+                pattern,
                 bump_res.current.clone().into(),
                 tag.clone(),
             )?;
@@ -319,7 +319,7 @@ impl CocoGitto {
         if !SETTINGS.disable_changelog {
             let pattern = self.get_bump_revspec(&bump_res.current);
             let changelog = self.get_monorepo_global_changelog_for_version(
-                &pattern,
+                pattern,
                 bump_res.current.clone().into(),
                 tag.clone(),
             )?;
@@ -544,7 +544,7 @@ impl CocoGitto {
             if !SETTINGS.disable_changelog {
                 let pattern = self.get_bump_revspec(&bump.current);
                 let changelog = self.get_package_changelog_with_target_version(
-                    &pattern,
+                    pattern,
                     tag.clone(),
                     package_name.as_str(),
                 )?;

--- a/crates/cocogitto/src/command/bump/monorepo.rs
+++ b/crates/cocogitto/src/command/bump/monorepo.rs
@@ -476,15 +476,12 @@ impl CocoGitto {
                         .map(|(i, name)| (name.as_str(), i))
                         .collect();
 
-                    packages.sort_by(|a, b| {
-                        let a_order = order_map.get(a.0.as_str()).unwrap_or(&usize::MAX);
-                        let b_order = order_map.get(b.0.as_str()).unwrap_or(&usize::MAX);
-                        a_order.cmp(b_order)
-                    });
+                    packages
+                        .sort_by_key(|pkg| order_map.get(pkg.0.as_str()).unwrap_or(&usize::MAX));
                 }
             }
         } else {
-            packages.sort_by(|a, b| a.1.bump_order.cmp(&b.1.bump_order));
+            packages.sort_by_key(|pkg| pkg.1.bump_order);
         }
 
         for (package_name, package) in packages {

--- a/crates/cocogitto/src/command/bump/monorepo.rs
+++ b/crates/cocogitto/src/command/bump/monorepo.rs
@@ -16,7 +16,7 @@ use anyhow::{bail, Result};
 use log::{info, warn};
 use tera::Tera;
 
-use crate::git::oid::OidOf;
+use crate::git::oid::ReleaseVersion;
 
 #[derive(Debug)]
 struct PackageBumpData {
@@ -167,17 +167,17 @@ impl CocoGitto {
             template_context.push(PackageBumpContext {
                 package_name: &bump.package_name,
                 package_path: &bump.package_path,
-                version: OidOf::Tag(bump.new_version.prefixed_tag.clone()),
+                version: bump.new_version.prefixed_tag.clone().into(),
                 from: Some(
                     bump.old_version
                         .as_ref()
-                        .map(|v| OidOf::Tag(v.prefixed_tag.clone()))
+                        .map(|v| v.prefixed_tag.clone().into())
                         .unwrap_or_else(|| {
                             let first = self
                                 .repository
                                 .get_first_commit()
                                 .expect("non empty repository");
-                            OidOf::Other(first)
+                            ReleaseVersion::new(first)
                         }),
                 ),
             })
@@ -187,7 +187,7 @@ impl CocoGitto {
             let pattern = self.get_bump_revspec(&bump_res.current);
             let changelog = self.get_monorepo_global_changelog_for_version(
                 &pattern,
-                OidOf::Tag(bump_res.current.clone()),
+                bump_res.current.clone().into(),
                 tag.clone(),
             )?;
 
@@ -311,7 +311,7 @@ impl CocoGitto {
             template_context.push(PackageBumpContext {
                 package_name: &bump.package_name,
                 package_path: &bump.package_path,
-                version: OidOf::Tag(bump.version.clone()),
+                version: bump.version.clone().into(),
                 from: None,
             })
         }
@@ -320,7 +320,7 @@ impl CocoGitto {
             let pattern = self.get_bump_revspec(&bump_res.current);
             let changelog = self.get_monorepo_global_changelog_for_version(
                 &pattern,
-                OidOf::Tag(bump_res.current.clone()),
+                bump_res.current.clone().into(),
                 tag.clone(),
             )?;
 

--- a/crates/cocogitto/src/command/bump/package.rs
+++ b/crates/cocogitto/src/command/bump/package.rs
@@ -37,7 +37,7 @@ impl CocoGitto {
         if !SETTINGS.disable_changelog {
             let pattern = self.get_bump_revspec(&bump_res.current);
             let changelog = self.get_package_changelog_with_target_version(
-                &pattern,
+                pattern,
                 tag.clone(),
                 opts.package_name,
             )?;

--- a/crates/cocogitto/src/command/bump/standard.rs
+++ b/crates/cocogitto/src/command/bump/standard.rs
@@ -30,7 +30,7 @@ impl CocoGitto {
         let pattern = self.get_bump_revspec(&bump_res.current);
 
         if !SETTINGS.disable_changelog {
-            let changelog = self.get_changelog_with_target_version(&pattern, tag.clone())?;
+            let changelog = self.get_changelog_with_target_version(pattern, tag.clone())?;
             changelog.pretty_print_bump_summary()?;
 
             let path = settings::changelog_path();

--- a/crates/cocogitto/src/command/changelog.rs
+++ b/crates/cocogitto/src/command/changelog.rs
@@ -43,9 +43,9 @@ impl CocoGitto {
                 continue;
             }
 
-            let from = Some(range.from_oid());
+            let from = Some(range.from_oid().into_version(Some(package_name)));
 
-            let version = range.to_oid();
+            let version = range.to_oid().into_version(Some(package_name));
 
             let context = PackageBumpContext {
                 package_name,
@@ -69,6 +69,7 @@ impl CocoGitto {
         };
 
         let changelog = Release::try_from(commit_range)?;
+
         changelog
             .into_markdown(template, ReleaseType::MonoRepo(context))
             .map_err(Into::into)

--- a/crates/cocogitto/src/command/changelog.rs
+++ b/crates/cocogitto/src/command/changelog.rs
@@ -14,7 +14,9 @@ impl CocoGitto {
     /// - `from` default value:latest tag or else first commit
     /// - `to` default value:`HEAD` or else first commit
     pub fn get_changelog(&self, pattern: &str, _with_child_releases: bool) -> Result<Release> {
-        let commit_range = self.repository.revwalk(pattern)?;
+        let commit_range = self
+            .repository
+            .revwalk(self.repository.revspec_from_str(pattern)?)?;
         Release::try_from(commit_range).map_err(Into::into)
     }
 
@@ -35,6 +37,7 @@ impl CocoGitto {
             .collect();
         package_data.sort_by_key(|&(name, _)| name);
 
+        let pattern = self.repository.revspec_from_str(pattern)?;
         for (package_name, package_path) in package_data.iter() {
             let range = self
                 .repository

--- a/crates/cocogitto/src/command/check.rs
+++ b/crates/cocogitto/src/command/check.rs
@@ -1,6 +1,7 @@
 use crate::conventional::commit::Commit;
 use crate::error::CogCheckReport;
 
+use crate::git::rev::revspec::RevSpecPattern2;
 use crate::git::tag::TagLookUpOptions;
 use crate::CocoGitto;
 use anyhow::anyhow;
@@ -16,16 +17,17 @@ impl CocoGitto {
         ignore_fixup_commits: bool,
         range: Option<String>,
     ) -> Result<()> {
-        let commit_range = if let Some(range) = range {
-            self.repository.revwalk(&range)?
+        let pattern = if let Some(range) = range {
+            self.repository.revspec_from_str(&range)?
         } else if check_from_latest_tag {
             let tag = self
                 .repository
                 .get_latest_tag(TagLookUpOptions::default())?;
-            self.repository.revwalk(&format!("{tag}.."))?
+            RevSpecPattern2::from(tag.oid.expect("latest tag should have oid"))
         } else {
-            self.repository.revwalk("..")?
+            RevSpecPattern2::full()
         };
+        let commit_range = self.repository.revwalk(pattern)?;
 
         let ignore_merge_commit_fn = |commit: &git2::Commit| commit.parent_count() <= 1;
         let ignore_fixup_commit_fn = |commit: &git2::Commit| {

--- a/crates/cocogitto/src/command/edit.rs
+++ b/crates/cocogitto/src/command/edit.rs
@@ -1,5 +1,6 @@
 use crate::conventional::commit::{verify, Commit};
 
+use crate::git::rev::revspec::RevSpecPattern2;
 use crate::git::tag::TagLookUpOptions;
 use crate::{CocoGitto, SETTINGS};
 use anyhow::{anyhow, Result};
@@ -13,14 +14,15 @@ use tempfile::TempDir;
 
 impl CocoGitto {
     pub fn check_and_edit(&self, from_latest_tag: bool) -> Result<()> {
-        let commits = if from_latest_tag {
+        let pattern = if from_latest_tag {
             let tag = self
                 .repository
                 .get_latest_tag(TagLookUpOptions::default())?;
-            self.repository.revwalk(&format!("{tag}.."))?
+            RevSpecPattern2::from(tag.oid.expect("latest tag should have oid"))
         } else {
-            self.repository.revwalk("..")?
+            RevSpecPattern2::full()
         };
+        let commits = self.repository.revwalk(pattern)?;
 
         let editor = std::env::var("EDITOR")
             .map_err(|_err| anyhow!("the 'EDITOR' environment variable was not found"))?;

--- a/crates/cocogitto/src/command/log.rs
+++ b/crates/cocogitto/src/command/log.rs
@@ -1,4 +1,5 @@
 use crate::conventional::commit::Commit;
+use crate::git::rev::revspec::RevSpecPattern2;
 use crate::git::tag::TagLookUpOptions;
 use crate::log::filter::CommitFilters;
 use crate::CocoGitto;
@@ -7,7 +8,7 @@ use std::fmt::Write;
 
 impl CocoGitto {
     pub fn get_log(&self, filters: CommitFilters) -> Result<String> {
-        let commits = self.repository.revwalk("..")?;
+        let commits = self.repository.revwalk(RevSpecPattern2::full())?;
         let logs = commits
             .iter_commits()
             // Remove merge commits

--- a/crates/cocogitto/src/conventional/bump.rs
+++ b/crates/cocogitto/src/conventional/bump.rs
@@ -4,6 +4,7 @@ use semver::{BuildMetadata, Prerelease, Version};
 
 use crate::conventional::error::BumpError;
 use crate::conventional::version::Increment;
+use crate::git::rev::revspec::RevSpecPattern2;
 use crate::git::tag::TagLookUpOptions;
 use crate::{Commit, IncrementCommand, Repository, Tag, SETTINGS};
 
@@ -155,10 +156,12 @@ impl Tag {
     fn get_version_from_commit_history(&self, repository: &Repository) -> Result<Tag, BumpError> {
         let changelog_start_oid = repository
             .get_latest_tag_oid(TagLookUpOptions::default())
-            .ok()
-            .unwrap_or_else(|| repository.get_first_commit().expect("non empty repository"));
+            .ok();
 
-        let commits = repository.revwalk(&format!("{changelog_start_oid}.."))?;
+        let commits = repository.revwalk(RevSpecPattern2 {
+            from: changelog_start_oid,
+            to: None,
+        })?;
 
         let commits: Vec<&Git2Commit> = commits
             .iter_commits()
@@ -190,11 +193,15 @@ impl Tag {
         let changelog_start_oid = repository
             .get_latest_package_tag(package)
             .ok()
-            .and_then(|tag| tag.oid)
-            .unwrap_or_else(|| repository.get_first_commit().expect("non empty repository"));
+            .and_then(|tag| tag.oid);
 
-        let commits = repository
-            .get_commit_range_for_package(&format!("{changelog_start_oid}.."), package)?;
+        let commits = repository.get_commit_range_for_package(
+            RevSpecPattern2 {
+                from: changelog_start_oid,
+                to: None,
+            },
+            package,
+        )?;
         let commits: Vec<&Git2Commit> = commits
             .iter_commits()
             .filter(&*FILTER_MERGE_COMMITS)
@@ -223,11 +230,12 @@ impl Tag {
     ) -> Result<Tag, BumpError> {
         let changelog_start_oid = repository
             .get_latest_tag_oid(TagLookUpOptions::default())
-            .ok()
-            .unwrap_or_else(|| repository.get_first_commit().expect("non empty repository"));
+            .ok();
 
-        let commits =
-            repository.get_commit_range_for_monorepo_global(&format!("{changelog_start_oid}.."))?;
+        let commits = repository.get_commit_range_for_monorepo_global(RevSpecPattern2 {
+            from: changelog_start_oid,
+            to: None,
+        })?;
 
         let commits: Vec<&Git2Commit> = commits
             .iter_commits()

--- a/crates/cocogitto/src/conventional/changelog/context.rs
+++ b/crates/cocogitto/src/conventional/changelog/context.rs
@@ -1,7 +1,7 @@
 use serde::Serialize;
 use tera::Context;
 
-use crate::{conventional::changelog::release::Release, git::oid::OidOf};
+use crate::{conventional::changelog::release::Release, git::oid::ReleaseVersion};
 
 /// A wrapper to append remote repository information to template context
 #[derive(Debug)]
@@ -21,8 +21,8 @@ pub struct MonoRepoContext<'a> {
 pub struct PackageBumpContext<'a> {
     pub package_name: &'a str,
     pub package_path: &'a str,
-    pub version: OidOf,
-    pub from: Option<OidOf>,
+    pub version: ReleaseVersion,
+    pub from: Option<ReleaseVersion>,
 }
 
 #[derive(Debug)]

--- a/crates/cocogitto/src/conventional/changelog/release.rs
+++ b/crates/cocogitto/src/conventional/changelog/release.rs
@@ -3,7 +3,7 @@ use conventional_commit_parser::commit::{Footer, Separator};
 use serde::Serialize;
 
 use crate::conventional::commit::Commit;
-use crate::git::oid::OidOf;
+use crate::git::oid::ReleaseVersion;
 use crate::git::rev::CommitIter;
 use crate::{settings, SETTINGS};
 use colored::Colorize;
@@ -13,91 +13,105 @@ use log::warn;
 
 #[derive(Debug, Serialize)]
 pub struct Release {
-    pub version: OidOf,
-    pub from: OidOf,
+    pub version: ReleaseVersion,
+    pub from: ReleaseVersion,
     pub date: NaiveDateTime,
     pub commits: Vec<ChangelogCommit>,
     pub previous: Option<Box<Release>>,
+}
+
+fn build_release_impl(
+    commits: CommitIter<'_>,
+    package: Option<&str>,
+) -> Result<Release, ChangelogError> {
+    let mut releases = vec![];
+    let mut commit_iter = commits.into_iter().rev().peekable();
+
+    while let Some((_oid, _commit)) = commit_iter.peek() {
+        let mut release_commits = vec![];
+
+        for (oid, commit) in commit_iter.by_ref() {
+            let version = oid.into_version(package);
+            if version.tag.is_some() {
+                release_commits.push((version, commit));
+                break;
+            }
+            release_commits.push((version, commit));
+        }
+
+        release_commits.reverse();
+        releases.push(release_commits);
+    }
+
+    let mut current = None;
+
+    for release in releases {
+        let next = Release {
+            version: release.first().unwrap().0.clone(),
+            from: current
+                .as_ref()
+                .map(|current: &Release| current.version.clone())
+                .unwrap_or(release.last().unwrap().0.clone()),
+            date: chrono::DateTime::from_timestamp(release.first().unwrap().1.time().seconds(), 0)
+                .map(|dt| dt.naive_utc())
+                .unwrap_or_else(|| Utc::now().naive_utc()),
+            commits: release
+                .iter()
+                .filter(|(_commit, commit)| commit.message().is_some())
+                .filter(|(_commit, commit)| {
+                    if SETTINGS.ignore_merge_commits {
+                        !commit.message().unwrap().starts_with("Merge")
+                    } else {
+                        true
+                    }
+                })
+                .filter(|(_commit, commit)| {
+                    if SETTINGS.ignore_fixup_commits {
+                        !commit.message().unwrap().starts_with("fixup!")
+                            && !commit.message().unwrap().starts_with("squash!")
+                            && !commit.message().unwrap().starts_with("amend!")
+                    } else {
+                        true
+                    }
+                })
+                .filter_map(|(_, commit)| match Commit::from_git_commit(commit) {
+                    Ok(commit) => {
+                        if !commit.should_omit() {
+                            Some(ChangelogCommit::from(commit))
+                        } else {
+                            None
+                        }
+                    }
+                    Err(err) => {
+                        let err = err.to_string().red();
+                        warn!("{}", err);
+                        None
+                    }
+                })
+                .collect(),
+            previous: current.map(Box::new),
+        };
+
+        current = Some(next);
+    }
+
+    current.ok_or(ChangelogError::EmptyRelease)
+}
+
+impl Release {
+    pub fn build_package(
+        commits: CommitIter<'_>,
+        package: &str,
+    ) -> Result<Release, ChangelogError> {
+        build_release_impl(commits, Some(package))
+    }
 }
 
 impl TryFrom<CommitIter<'_>> for Release {
     type Error = ChangelogError;
 
     fn try_from(commits: CommitIter<'_>) -> Result<Self, Self::Error> {
-        let mut releases = vec![];
-        let mut commit_iter = commits.into_iter().rev().peekable();
-
-        while let Some((_oid, _commit)) = commit_iter.peek() {
-            let mut release_commits = vec![];
-
-            for (oid, commit) in commit_iter.by_ref() {
-                if matches!(oid, OidOf::Tag(_)) {
-                    release_commits.push((oid, commit));
-                    break;
-                }
-                release_commits.push((oid, commit));
-            }
-
-            release_commits.reverse();
-            releases.push(release_commits);
-        }
-
-        let mut current = None;
-
-        for release in releases {
-            let next = Release {
-                version: release.first().unwrap().0.clone(),
-                from: current
-                    .as_ref()
-                    .map(|current: &Release| current.version.clone())
-                    .unwrap_or(release.last().unwrap().0.clone()),
-                date: chrono::DateTime::from_timestamp(
-                    release.first().unwrap().1.time().seconds(),
-                    0,
-                )
-                .map(|dt| dt.naive_utc())
-                .unwrap_or_else(|| Utc::now().naive_utc()),
-                commits: release
-                    .iter()
-                    .filter(|(_commit, commit)| commit.message().is_some())
-                    .filter(|(_commit, commit)| {
-                        if SETTINGS.ignore_merge_commits {
-                            !commit.message().unwrap().starts_with("Merge")
-                        } else {
-                            true
-                        }
-                    })
-                    .filter(|(_commit, commit)| {
-                        if SETTINGS.ignore_fixup_commits {
-                            !commit.message().unwrap().starts_with("fixup!")
-                                && !commit.message().unwrap().starts_with("squash!")
-                                && !commit.message().unwrap().starts_with("amend!")
-                        } else {
-                            true
-                        }
-                    })
-                    .filter_map(|(_, commit)| match Commit::from_git_commit(commit) {
-                        Ok(commit) => {
-                            if !commit.should_omit() {
-                                Some(ChangelogCommit::from(commit))
-                            } else {
-                                None
-                            }
-                        }
-                        Err(err) => {
-                            let err = err.to_string().red();
-                            warn!("{}", err);
-                            None
-                        }
-                    })
-                    .collect(),
-                previous: current.map(Box::new),
-            };
-
-            current = Some(next);
-        }
-
-        current.ok_or(ChangelogError::EmptyRelease)
+        build_release_impl(commits, None)
     }
 }
 

--- a/crates/cocogitto/src/conventional/changelog/serde.rs
+++ b/crates/cocogitto/src/conventional/changelog/serde.rs
@@ -2,7 +2,6 @@ use serde::ser::SerializeStruct;
 use serde::{Serialize, Serializer};
 
 use crate::conventional::changelog::release::{ChangelogCommit, ChangelogFooter};
-use crate::git::oid::OidOf;
 use crate::git::tag::Tag;
 use crate::COMMITS_METADATA;
 
@@ -57,27 +56,6 @@ impl Serialize for ChangelogCommit {
         )?;
         commit.serialize_field("footers", footers)?;
         commit.end()
-    }
-}
-
-impl Serialize for OidOf {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let mut oidof = serializer.serialize_struct("OidOf", 1)?;
-        match self {
-            OidOf::Tag(tag) => {
-                oidof.serialize_field("tag", &tag.to_string())?;
-                if let Some(oid) = tag.oid() {
-                    oidof.serialize_field("id", &oid.to_string())?;
-                }
-            }
-            OidOf::FirstCommit(oid) | OidOf::Head(oid) | OidOf::Other(oid) => {
-                oidof.serialize_field("id", &oid.to_string())?
-            }
-        };
-        oidof.end()
     }
 }
 

--- a/crates/cocogitto/src/conventional/changelog/tests/fixtures.rs
+++ b/crates/cocogitto/src/conventional/changelog/tests/fixtures.rs
@@ -1,7 +1,6 @@
 use crate::conventional::changelog::context::{MonoRepoContext, PackageBumpContext, RemoteContext};
 use crate::conventional::changelog::release::{ChangelogCommit, Release};
 use crate::conventional::commit::Commit;
-use crate::git::oid::OidOf;
 use crate::git::tag::Tag;
 use chrono::NaiveDateTime;
 use conventional_commit_parser::commit::{CommitType, ConventionalCommit, Footer, Separator};
@@ -15,20 +14,18 @@ impl<'a> ReleaseFixture {
     pub fn builder() -> ReleaseFixture {
         ReleaseFixture {
             release: Release {
-                version: OidOf::Tag(
-                    Tag::from_str(
-                        "1.0.0",
-                        Some(Oid::from_str("9bb5facac5724bc81385fdd740fedbb49056da00").unwrap()),
-                    )
-                    .unwrap(),
-                ),
-                from: OidOf::Tag(
-                    Tag::from_str(
-                        "0.1.0",
-                        Some(Oid::from_str("fae3a288a1bc69b14f85a1d5fe57cee1964acd60").unwrap()),
-                    )
-                    .unwrap(),
-                ),
+                version: Tag::from_str(
+                    "1.0.0",
+                    Some(Oid::from_str("9bb5facac5724bc81385fdd740fedbb49056da00").unwrap()),
+                )
+                .unwrap()
+                .into(),
+                from: Tag::from_str(
+                    "0.1.0",
+                    Some(Oid::from_str("fae3a288a1bc69b14f85a1d5fe57cee1964acd60").unwrap()),
+                )
+                .unwrap()
+                .into(),
                 date: NaiveDateTime::parse_from_str("2015-09-05 23:56:04", "%Y-%m-%d %H:%M:%S")
                     .unwrap(),
                 commits: vec![],
@@ -192,38 +189,39 @@ pub fn monorepo_context<'a>() -> MonoRepoContext<'a> {
             PackageBumpContext {
                 package_name: "one",
                 package_path: "crates/one",
-                version: OidOf::Tag(
-                    Tag::from_str(
-                        "0.1.0",
-                        Some(Oid::from_str("fae3a288a1bc69b14f85a1d5fe57cee1964acd60").unwrap()),
-                    )
-                    .unwrap(),
-                ),
-                from: Some(OidOf::Tag(
+                version: Tag::from_str(
+                    "0.1.0",
+                    Some(Oid::from_str("fae3a288a1bc69b14f85a1d5fe57cee1964acd60").unwrap()),
+                )
+                .unwrap()
+                .into(),
+                from: Some(
                     Tag::from_str(
                         "0.2.0",
                         Some(Oid::from_str("fae3a288a1bc69b14f85a1d5fe57cee1964acd60").unwrap()),
                     )
-                    .unwrap(),
-                )),
+                    .unwrap()
+                    .into(),
+                ),
             },
             PackageBumpContext {
                 package_name: "two",
                 package_path: "crates/two",
-                version: OidOf::Tag(
-                    Tag::from_str(
-                        "0.2.0",
-                        Some(Oid::from_str("fae3a288a1bc69b14f85a1d5fe57cee1964acd60").unwrap()),
-                    )
-                    .unwrap(),
-                ),
-                from: Some(OidOf::Tag(
+                version: Tag::from_str(
+                    "0.2.0",
+                    Some(Oid::from_str("fae3a288a1bc69b14f85a1d5fe57cee1964acd60").unwrap()),
+                )
+                .unwrap()
+                .into(),
+
+                from: Some(
                     Tag::from_str(
                         "0.3.0",
                         Some(Oid::from_str("fae3a288a1bc69b14f85a1d5fe57cee1964acd60").unwrap()),
                     )
-                    .unwrap(),
-                )),
+                    .unwrap()
+                    .into(),
+                ),
             },
         ],
     }
@@ -236,25 +234,23 @@ pub fn default_package_context<'a>() -> MonoRepoContext<'a> {
             PackageBumpContext {
                 package_name: "one",
                 package_path: "crates/one",
-                version: OidOf::Tag(
-                    Tag::from_str(
-                        "0.1.0",
-                        Some(Oid::from_str("fae3a288a1bc69b14f85a1d5fe57cee1964acd60").unwrap()),
-                    )
-                    .unwrap(),
-                ),
+                version: Tag::from_str(
+                    "0.1.0",
+                    Some(Oid::from_str("fae3a288a1bc69b14f85a1d5fe57cee1964acd60").unwrap()),
+                )
+                .unwrap()
+                .into(),
                 from: None,
             },
             PackageBumpContext {
                 package_name: "two",
                 package_path: "crates/two",
-                version: OidOf::Tag(
-                    Tag::from_str(
-                        "0.2.0",
-                        Some(Oid::from_str("fae3a288a1bc69b14f85a1d5fe57cee1964acd60").unwrap()),
-                    )
-                    .unwrap(),
-                ),
+                version: Tag::from_str(
+                    "0.2.0",
+                    Some(Oid::from_str("fae3a288a1bc69b14f85a1d5fe57cee1964acd60").unwrap()),
+                )
+                .unwrap()
+                .into(),
                 from: None,
             },
         ],

--- a/crates/cocogitto/src/conventional/changelog/tests/mod.rs
+++ b/crates/cocogitto/src/conventional/changelog/tests/mod.rs
@@ -11,6 +11,7 @@ use crate::conventional::changelog::tests::fixtures::{
     default_package_context, default_remote_context, monorepo_context, ReleaseFixture,
 };
 use crate::git::repository::Repository;
+use crate::git::rev::revspec::RevSpecPattern2;
 
 macro_rules! assert_doc_eq {
     ($changelog:expr, $doc:literal) => {
@@ -55,7 +56,7 @@ macro_rules! changelog_test {
 #[test]
 fn should_get_a_release() -> anyhow::Result<()> {
     let repo = Repository::open(".")?;
-    let iter = repo.revwalk("..")?;
+    let iter = repo.revwalk(RevSpecPattern2::full())?;
     let release = Release::try_from(iter);
     assert_that!(release)
         .is_ok()

--- a/crates/cocogitto/src/error.rs
+++ b/crates/cocogitto/src/error.rs
@@ -1,13 +1,13 @@
 use std::fmt::{self, Debug, Display, Formatter};
 
-use crate::git::oid::OidOf;
+use crate::git::oid::CommitInfo;
 
 use crate::conventional::error::ConventionalCommitError;
 use colored::*;
 
 #[derive(Debug)]
 pub(crate) struct CogCheckReport {
-    pub from: OidOf,
+    pub from: CommitInfo,
     pub errors: Vec<ConventionalCommitError>,
 }
 

--- a/crates/cocogitto/src/git/monorepo.rs
+++ b/crates/cocogitto/src/git/monorepo.rs
@@ -15,7 +15,10 @@ impl Repository {
 #[cfg(test)]
 mod test {
 
-    use crate::test_helpers::{git_init_no_gpg, mkdir};
+    use crate::{
+        git::rev::revspec::RevSpecPattern2,
+        test_helpers::{git_init_no_gpg, mkdir},
+    };
     use anyhow::Result;
     use cmd_lib::run_cmd;
     use indoc::formatdoc;
@@ -60,7 +63,7 @@ mod test {
         )?;
 
         // Act
-        let range = repo.get_commit_range_for_package("..HEAD", "two")?;
+        let range = repo.get_commit_range_for_package(RevSpecPattern2::full(), "two")?;
         let range = range.into_iter().collect::<Vec<_>>();
 
         // Assert

--- a/crates/cocogitto/src/git/oid.rs
+++ b/crates/cocogitto/src/git/oid.rs
@@ -10,8 +10,6 @@ use crate::git::tag::Tag;
 pub struct CommitInfo {
     pub oid: Oid,
     pub tags: Vec<Tag>,
-    pub first: bool,
-    pub head: bool,
 }
 
 impl CommitInfo {
@@ -19,8 +17,6 @@ impl CommitInfo {
         Self {
             oid,
             tags: Vec::new(),
-            first: false,
-            head: false,
         }
     }
 
@@ -38,8 +34,6 @@ impl From<Tag> for CommitInfo {
         Self {
             oid: value.oid.unwrap_or(Oid::zero()),
             tags: vec![value],
-            first: false,
-            head: false,
         }
     }
 }
@@ -48,8 +42,6 @@ impl Display for CommitInfo {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         if let Some(tag) = self.tags.first() {
             tag.fmt(f)
-        } else if self.head {
-            f.write_str("HEAD")
         } else {
             self.oid.fmt(f)
         }

--- a/crates/cocogitto/src/git/oid.rs
+++ b/crates/cocogitto/src/git/oid.rs
@@ -1,35 +1,95 @@
 use std::fmt::{Display, Formatter};
 
 use git2::Oid;
+use serde::{Serialize, Serializer};
 
 use crate::git::tag::Tag;
 
 /// A wrapper for git2 oid including tags and HEAD ref
 #[derive(Debug, PartialEq, Eq, Clone)]
-pub enum OidOf {
-    Tag(Tag),
-    Head(Oid),
-    Other(Oid),
-    FirstCommit(Oid),
+pub struct CommitInfo {
+    pub oid: Oid,
+    pub tags: Vec<Tag>,
+    pub first: bool,
+    pub head: bool,
 }
 
-impl OidOf {
-    pub fn oid(&self) -> &Oid {
-        match self {
-            OidOf::Tag(t) => t.oid_unchecked(),
-            OidOf::Head(o) | OidOf::Other(o) | OidOf::FirstCommit(o) => o,
+impl CommitInfo {
+    pub fn new(oid: Oid) -> Self {
+        Self {
+            oid,
+            tags: Vec::new(),
+            first: false,
+            head: false,
+        }
+    }
+
+    pub fn into_version(self, package: Option<&str>) -> ReleaseVersion {
+        let tag = self
+            .tags
+            .into_iter()
+            .find(|tag| tag.package.as_deref() == package);
+        ReleaseVersion { id: self.oid, tag }
+    }
+}
+
+impl From<Tag> for CommitInfo {
+    fn from(value: Tag) -> Self {
+        Self {
+            oid: value.oid.unwrap_or(Oid::zero()),
+            tags: vec![value],
+            first: false,
+            head: false,
         }
     }
 }
 
-impl Display for OidOf {
-    /// Print the oid according to it's type
+impl Display for CommitInfo {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match self {
-            OidOf::Tag(tag) => write!(f, "{tag}"),
-            OidOf::Head(_) => write!(f, "HEAD"),
-            OidOf::Other(oid) => write!(f, "{}", &oid.to_string()),
-            OidOf::FirstCommit(oid) => write!(f, "{}", &oid.to_string()),
+        if let Some(tag) = self.tags.first() {
+            tag.fmt(f)
+        } else if self.head {
+            f.write_str("HEAD")
+        } else {
+            self.oid.fmt(f)
+        }
+    }
+}
+
+/// A lightweight wrapper for git2 oid
+#[derive(Debug, Serialize, Clone, PartialEq, Eq)]
+pub struct ReleaseVersion {
+    #[serde(serialize_with = "serialize_oid")]
+    pub id: Oid,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tag: Option<Tag>,
+}
+
+fn serialize_oid<S: Serializer>(oid: &Oid, s: S) -> Result<S::Ok, S::Error> {
+    s.serialize_str(&oid.to_string())
+}
+
+impl ReleaseVersion {
+    pub fn new(oid: Oid) -> Self {
+        Self { id: oid, tag: None }
+    }
+}
+
+impl From<Tag> for ReleaseVersion {
+    fn from(value: Tag) -> Self {
+        Self {
+            id: value.oid.unwrap_or(Oid::zero()),
+            tag: Some(value),
+        }
+    }
+}
+
+impl Display for ReleaseVersion {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        if let Some(tag) = &self.tag {
+            tag.fmt(f)
+        } else {
+            self.id.fmt(f)
         }
     }
 }

--- a/crates/cocogitto/src/git/repository.rs
+++ b/crates/cocogitto/src/git/repository.rs
@@ -1,15 +1,18 @@
 use std::path::Path;
+use std::sync::Mutex;
 use std::{
     fmt::{Debug, Formatter},
     path::PathBuf,
 };
 
-use crate::git::error::Git2Error;
 use git2::{
     Commit as Git2Commit, IndexAddOption, Object, ObjectType, Oid, Repository as Git2Repository,
 };
 
-pub(crate) struct Repository(pub(crate) Git2Repository);
+use crate::git::error::Git2Error;
+use crate::git::rev::cache::RepoCache;
+
+pub(crate) struct Repository(pub(crate) Git2Repository, pub(super) Mutex<RepoCache>);
 
 impl Repository {
     pub(crate) fn signing_key(&self) -> Result<String, Git2Error> {
@@ -73,12 +76,12 @@ impl Repository {
     pub(crate) fn init<S: AsRef<Path> + ?Sized>(path: &S) -> Result<Repository, Git2Error> {
         let repository =
             Git2Repository::init(path).map_err(Git2Error::FailedToInitializeRepository)?;
-        Ok(Repository(repository))
+        Ok(Repository(repository, Mutex::new(RepoCache::empty())))
     }
 
     pub(crate) fn open<S: AsRef<Path> + ?Sized>(path: &S) -> Result<Repository, Git2Error> {
         let repo = Git2Repository::discover(path).map_err(Git2Error::FailedToOpenRepository)?;
-        Ok(Repository(repo))
+        Ok(Repository(repo, Mutex::new(RepoCache::empty())))
     }
 
     pub(crate) fn get_repo_dir(&self) -> Option<&Path> {

--- a/crates/cocogitto/src/git/rev/cache.rs
+++ b/crates/cocogitto/src/git/rev/cache.rs
@@ -51,10 +51,10 @@ impl RepoCache {
 
     fn fill(&mut self, repo: &Repository) -> Result<(), Git2Error> {
         self.head = repo.get_head_commit_oid()?;
-        self.insert_oid(self.head).head = true;
+        self.insert_oid(self.head);
 
         self.first = repo.get_first_commit()?;
-        self.insert_oid(self.first).first = true;
+        self.insert_oid(self.first);
 
         // Tags, now performant
         // first, list all tags
@@ -109,10 +109,6 @@ impl RepoCache {
             .get(&oid)
             .cloned()
             .unwrap_or(CommitInfo::new(oid))
-    }
-
-    pub fn head_commit_info(&self) -> CommitInfo {
-        self.commits[&self.head].clone()
     }
 }
 

--- a/crates/cocogitto/src/git/rev/cache.rs
+++ b/crates/cocogitto/src/git/rev/cache.rs
@@ -1,80 +1,130 @@
+use git2::Oid;
+
 use crate::git::error::{Git2Error, TagError};
-use crate::git::oid::OidOf;
+use crate::git::oid::CommitInfo;
 use crate::git::repository::Repository;
 use crate::git::tag::Tag;
-use std::collections::{BTreeMap, HashMap};
-use std::sync::{Mutex, MutexGuard};
+use std::collections::HashMap;
+use std::sync::MutexGuard;
 
-static REPO_CACHE: Mutex<BTreeMap<String, Vec<OidOf>>> = Mutex::new(BTreeMap::new());
-
-pub(crate) fn get_cache(repo: &Repository) -> MutexGuard<'_, BTreeMap<String, Vec<OidOf>>> {
-    let mut cache = REPO_CACHE.lock().unwrap();
-    if cache.is_empty() {
-        build_cache(repo, &mut cache).expect("failed to construct tag cache");
-    }
-    cache
+/// Stores commit information, mainly tags
+///
+/// To avoid having duplicate [`CommitInfo`] instances for the same commit
+/// due to mutliple possible references (full/short oid, multiple tag names),
+/// the cache is split into two:
+/// * `refs` contains all ways to reference a commit and maps those to the commit oid
+/// * `commits` contains the actual [`CommitInfo`]
+///
+/// Additionally, the [`Oid`] of the head commit and first commit
+/// aswell as a list of all [`Tag`]s is stored in the cache.
+#[derive(Debug)]
+pub(crate) struct RepoCache {
+    pub refs: HashMap<String, Oid>,
+    pub commits: HashMap<Oid, CommitInfo>,
+    pub head: Oid,
+    pub first: Oid,
+    pub tags: Vec<Tag>,
 }
 
-fn build_cache(
-    repo: &Repository,
-    cache: &mut BTreeMap<String, Vec<OidOf>>,
-) -> Result<(), Git2Error> {
-    if !cache.is_empty() {
-        return Ok(());
-    }
-
-    let mut add_entry = |key: String, value: OidOf| {
-        cache.entry(key).or_default().push(value);
-    };
-
-    // HEAD
-    let head = repo.get_head_commit()?.id();
-    add_entry(head.to_string(), OidOf::Head(head));
-
-    // First Commit
-    let first = OidOf::FirstCommit(repo.get_first_commit()?);
-    add_entry(first.to_string(), first);
-
-    // Tags, now performant
-    // first, list all tags
-    let tags = repo.0.tag_names(None)?;
-    let tags = tags
-        .into_iter()
-        .flatten()
-        .filter_map(|tag| repo.resolve_tag(tag).ok())
-        .filter_map(|tag| Some((tag.oid?, tag)));
-
-    // use a hashmap to easily access by oid
-    let mut tag_map = HashMap::<_, Vec<_>>::new();
-    for (oid, tag) in tags {
-        tag_map.entry(oid).or_default().push(tag);
-    }
-
-    // create revwalk for `..` (all commits reachable from HEAD)
-    let mut tags_from_head = Vec::new();
-    let mut revwalk = repo.0.revwalk()?;
-    revwalk.push_head()?;
-
-    // filter tags by those reachable from HEAD
-    for oid in revwalk {
-        let oid = oid?;
-        if let Some(tags) = tag_map.remove(&oid) {
-            tags_from_head.extend(tags);
+impl RepoCache {
+    pub fn empty() -> Self {
+        Self {
+            refs: HashMap::new(),
+            commits: HashMap::new(),
+            head: Oid::zero(),
+            first: Oid::zero(),
+            tags: Vec::new(),
         }
     }
 
-    // actually add tags to cache
-    for tag in tags_from_head {
-        if let Some(oid) = &tag.oid {
-            add_entry(oid.to_string(), OidOf::Tag(tag.clone()));
-        }
-        add_entry(tag.to_string(), OidOf::Tag(tag))
+    pub fn clear(&mut self) {
+        self.refs.clear();
+        self.commits.clear();
+        self.head = Oid::zero();
+        self.first = Oid::zero();
+        self.tags.clear();
     }
 
-    Ok(())
+    fn is_empty(&self) -> bool {
+        self.refs.is_empty() && self.commits.is_empty()
+    }
+
+    fn fill(&mut self, repo: &Repository) -> Result<(), Git2Error> {
+        self.head = repo.get_head_commit_oid()?;
+        self.insert_oid(self.head).head = true;
+
+        self.first = repo.get_first_commit()?;
+        self.insert_oid(self.first).first = true;
+
+        // Tags, now performant
+        // first, list all tags
+        let tags = repo.0.tag_names(None)?;
+        let tags = tags
+            .into_iter()
+            .flatten()
+            .filter_map(|tag| repo.resolve_tag(tag).ok())
+            .filter_map(|tag| Some((tag.oid?, tag)));
+
+        // use a hashmap to easily access by oid
+        let mut tag_map = HashMap::<_, Vec<_>>::new();
+        for (oid, tag) in tags {
+            tag_map.entry(oid).or_default().push(tag);
+        }
+
+        // create revwalk for `..` (all commits reachable from HEAD)
+        let mut tags_from_head = Vec::new();
+        let mut revwalk = repo.0.revwalk()?;
+        revwalk.push_head()?;
+
+        // filter tags by those reachable from HEAD
+        for oid in revwalk {
+            let oid = oid?;
+            if let Some(tags) = tag_map.remove(&oid) {
+                tags_from_head.extend(tags);
+            }
+        }
+
+        // actually add tags to cache
+        for tag in tags_from_head {
+            if let Some(oid) = &tag.oid {
+                self.insert_oid(*oid).tags.push(tag.clone());
+                self.refs.insert(tag.to_string(), *oid);
+                self.tags.push(tag);
+            }
+        }
+
+        Ok(())
+    }
+
+    fn insert_oid(&mut self, oid: Oid) -> &mut CommitInfo {
+        let long = oid.to_string();
+        let short = long[..7].to_string();
+        self.refs.insert(long, oid);
+        self.refs.insert(short, oid);
+        self.commits.entry(oid).or_insert(CommitInfo::new(oid))
+    }
+
+    pub fn get_info(&self, oid: Oid) -> CommitInfo {
+        self.commits
+            .get(&oid)
+            .cloned()
+            .unwrap_or(CommitInfo::new(oid))
+    }
+
+    pub fn head_commit_info(&self) -> CommitInfo {
+        self.commits[&self.head].clone()
+    }
 }
 
 impl Repository {
+    pub fn get_cache(&self) -> MutexGuard<'_, RepoCache> {
+        let mut cache = self.1.lock().unwrap();
+        if cache.is_empty() {
+            cache.fill(self).expect("failed to construct tag cache");
+        }
+        cache
+    }
+
     fn resolve_tag(&self, tag: &str) -> Result<Tag, Git2Error> {
         let oid = self
             .0
@@ -91,7 +141,6 @@ impl Repository {
 #[cfg(test)]
 mod test {
     use crate::git::repository::Repository;
-    use crate::git::rev::cache::get_cache;
     use crate::test_helpers::git_init_no_gpg;
     use cmd_lib::run_cmd;
     use sealed_test::prelude::*;
@@ -100,7 +149,7 @@ mod test {
     #[test]
     fn init_cache_ok() -> anyhow::Result<()> {
         let repo = Repository::open(".")?;
-        let cache = get_cache(&repo);
+        let cache = repo.get_cache();
         assert_that!(cache.is_empty()).is_false();
         Ok(())
     }
@@ -168,8 +217,8 @@ mod test {
         )?;
 
         // Act
-        let cache = get_cache(&repo);
-        let tag = cache.get("1.0.0");
+        let cache = repo.get_cache();
+        let tag = cache.refs.get("1.0.0");
 
         // Assert
         assert_that!(tag).is_none();

--- a/crates/cocogitto/src/git/rev/mod.rs
+++ b/crates/cocogitto/src/git/rev/mod.rs
@@ -1,6 +1,6 @@
 use git2::Commit;
 
-use crate::git::oid::OidOf;
+use crate::git::oid::CommitInfo;
 
 pub mod cache;
 pub mod filters;
@@ -8,18 +8,18 @@ pub mod revspec;
 pub mod revwalk;
 
 #[derive(Debug)]
-pub struct CommitIter<'repo>(Vec<(OidOf, Commit<'repo>)>);
+pub struct CommitIter<'repo>(Vec<(CommitInfo, Commit<'repo>)>);
 
 impl<'repo> CommitIter<'repo> {
-    pub fn single(oid_of: OidOf, commit: Commit<'repo>) -> Self {
+    pub fn single(oid_of: CommitInfo, commit: Commit<'repo>) -> Self {
         CommitIter::<'repo>(vec![(oid_of, commit)])
     }
 
-    pub fn from_oid(&self) -> OidOf {
+    pub fn from_oid(&self) -> CommitInfo {
         self.0.last().expect("non empty commit range").0.clone()
     }
 
-    pub fn to_oid(&self) -> OidOf {
+    pub fn to_oid(&self) -> CommitInfo {
         self.0.first().expect("non empty commit range").0.clone()
     }
 
@@ -33,7 +33,7 @@ impl<'repo> CommitIter<'repo> {
 }
 
 impl<'repo> IntoIterator for CommitIter<'repo> {
-    type Item = (OidOf, Commit<'repo>);
+    type Item = (CommitInfo, Commit<'repo>);
     type IntoIter = std::vec::IntoIter<Self::Item>;
 
     fn into_iter(self) -> Self::IntoIter {

--- a/crates/cocogitto/src/git/rev/revspec.rs
+++ b/crates/cocogitto/src/git/rev/revspec.rs
@@ -1,7 +1,6 @@
 use crate::git::error::Git2Error;
-use crate::git::oid::OidOf;
+use crate::git::oid::CommitInfo;
 use crate::git::repository::Repository;
-use crate::git::rev::cache::get_cache;
 use crate::git::tag::Tag;
 use git2::Oid;
 use std::fmt;
@@ -9,20 +8,20 @@ use std::fmt::Formatter;
 
 #[derive(Debug, Clone)]
 pub enum RevSpecPattern2 {
-    Range { from: OidOf, to: OidOf },
-    AtTag { from: OidOf, to: OidOf },
+    Range { from: CommitInfo, to: CommitInfo },
+    AtTag { from: CommitInfo, to: CommitInfo },
 }
 
 impl RevSpecPattern2 {
-    pub fn from(&self) -> &Oid {
+    pub fn from(&self) -> Oid {
         match self {
-            RevSpecPattern2::AtTag { from, .. } | RevSpecPattern2::Range { from, .. } => from.oid(),
+            RevSpecPattern2::AtTag { from, .. } | RevSpecPattern2::Range { from, .. } => from.oid,
         }
     }
 
-    pub fn to(&self) -> &Oid {
+    pub fn to(&self) -> Oid {
         match self {
-            RevSpecPattern2::AtTag { to, .. } | RevSpecPattern2::Range { to, .. } => to.oid(),
+            RevSpecPattern2::AtTag { to, .. } | RevSpecPattern2::Range { to, .. } => to.oid,
         }
     }
 }
@@ -31,72 +30,49 @@ impl Repository {
     pub(super) fn revspec_from_str(&self, s: &str) -> Result<RevSpecPattern2, Git2Error> {
         if let Some((from, to)) = s.split_once("..") {
             let from = if from.is_empty() {
-                OidOf::Other(self.get_first_commit()?)
+                CommitInfo::new(self.get_first_commit()?)
             } else {
-                self.resolve_oid_of(from)?
+                self.get_commit_info(from)?
             };
 
             let to = if to.is_empty() {
-                OidOf::Head(self.get_head_commit_oid()?)
+                self.get_cache().head_commit_info()
             } else {
-                self.resolve_oid_of(to)?
+                self.get_commit_info(to)?
             };
 
             Ok(RevSpecPattern2::Range { from, to })
         } else if let Ok(tag) = Tag::from_str(s, None) {
-            let previous = self.get_previous_tag(&tag)?.map(OidOf::Tag);
+            let previous = self.get_previous_tag(&tag)?.map(Into::into);
 
             let previous = match previous {
-                None => OidOf::Other(self.get_first_commit()?),
+                None => CommitInfo::new(self.get_first_commit()?),
                 Some(previous) => previous,
             };
 
             Ok(RevSpecPattern2::AtTag {
                 from: previous,
-                to: self.resolve_oid_of(s)?,
+                to: self.get_commit_info(s)?,
             })
         } else {
             Err(Git2Error::InvalidCommitRangePattern(s.to_string()))
         }
     }
 
-    pub(super) fn resolve_oid_of(&self, from: &str) -> Result<OidOf, Git2Error> {
-        self.resolve_oid_of_package(from, None)
-    }
+    pub(super) fn get_commit_info(&self, from: &str) -> Result<CommitInfo, Git2Error> {
+        let cache = self.get_cache();
+        let oid = cache
+            .refs
+            .get(from)
+            .copied()
+            .or_else(|| Some(self.0.revparse_single(from).ok()?.id()))
+            .ok_or(Git2Error::UnknownRevision(from.to_string()))?;
 
-    pub(super) fn resolve_oid_of_package(
-        &self,
-        from: &str,
-        package: Option<&str>,
-    ) -> Result<OidOf, Git2Error> {
-        let cache = get_cache(self);
-
-        // note: `get` cannot be used as `starts_with` is used for comparison
-        let oids = cache
-            .iter()
-            .find(|(k, _)| k.starts_with(from))
-            .map(|(_, v)| v);
-
-        let oid = oids
-            .and_then(|v| {
-                v.iter().rfind(|oid| {
-                    if let OidOf::Tag(tag) = oid {
-                        tag.package.as_deref() == package
-                    } else {
-                        true
-                    }
-                })
-            })
-            .cloned();
-        if let Some(oid) = oid {
-            Ok(oid)
-        } else {
-            let object = self
-                .0
-                .revparse_single(from)
-                .map_err(|_| Git2Error::UnknownRevision(from.to_string()))?;
-            Ok(OidOf::Other(object.id()))
-        }
+        Ok(cache
+            .commits
+            .get(&oid)
+            .cloned()
+            .unwrap_or(CommitInfo::new(oid)))
     }
 }
 
@@ -112,7 +88,7 @@ impl fmt::Display for RevSpecPattern2 {
 
 #[cfg(test)]
 mod test {
-    use crate::git::oid::OidOf;
+    use crate::git::oid::CommitInfo;
     use crate::git::rev::revspec::RevSpecPattern2;
     use crate::git::tag::Tag;
     use crate::test_helpers::{commit, git_init_no_gpg, git_tag};
@@ -129,14 +105,16 @@ mod test {
         let commit_oid = commit("chore: v1")?;
         git_tag("1.0.0")?;
 
-        let oid = repo.resolve_oid_of("1.0.0")?;
+        let oid = repo.get_commit_info("1.0.0")?;
 
-        assert_that!(oid).is_equal_to(OidOf::Tag(Tag {
+        let mut info = CommitInfo::from(Tag {
             package: None,
             prefix: None,
             version: Version::new(1, 0, 0),
             oid: Some(Oid::from_str(&commit_oid)?),
-        }));
+        });
+        info.head = true;
+        assert_that!(oid).is_equal_to(info);
 
         Ok(())
     }
@@ -147,9 +125,11 @@ mod test {
         commit("chore: first commit")?;
         let commit_oid = commit("chore: other")?;
 
-        let oid = repo.resolve_oid_of(&commit_oid)?;
+        let oid = repo.get_commit_info(&commit_oid)?;
 
-        assert_that!(oid).is_equal_to(OidOf::Head(Oid::from_str(&commit_oid)?));
+        let mut info = CommitInfo::new(Oid::from_str(&commit_oid)?);
+        info.head = true;
+        assert_that!(oid).is_equal_to(info);
 
         Ok(())
     }
@@ -161,9 +141,9 @@ mod test {
         let commit_oid = commit("chore: other")?;
         commit("chore: head")?;
 
-        let oid = repo.resolve_oid_of(&commit_oid)?;
+        let oid = repo.get_commit_info(&commit_oid)?;
 
-        assert_that!(oid).is_equal_to(OidOf::Other(Oid::from_str(&commit_oid)?));
+        assert_that!(oid).is_equal_to(CommitInfo::new(Oid::from_str(&commit_oid)?));
 
         Ok(())
     }
@@ -174,7 +154,7 @@ mod test {
         commit("chore: first commit")?;
         commit("chore: other")?;
 
-        let oid = repo.resolve_oid_of("v32");
+        let oid = repo.get_commit_info("v32");
 
         assert_that!(oid).is_err();
 

--- a/crates/cocogitto/src/git/rev/revspec.rs
+++ b/crates/cocogitto/src/git/rev/revspec.rs
@@ -1,94 +1,80 @@
 use crate::git::error::Git2Error;
-use crate::git::oid::CommitInfo;
 use crate::git::repository::Repository;
 use crate::git::tag::Tag;
 use git2::Oid;
-use std::fmt;
-use std::fmt::Formatter;
 
-#[derive(Debug, Clone)]
-pub enum RevSpecPattern2 {
-    Range { from: CommitInfo, to: CommitInfo },
-    AtTag { from: CommitInfo, to: CommitInfo },
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct RevSpecPattern2 {
+    pub from: Option<Oid>,
+    pub to: Option<Oid>,
 }
 
 impl RevSpecPattern2 {
-    pub fn from(&self) -> Oid {
-        match self {
-            RevSpecPattern2::AtTag { from, .. } | RevSpecPattern2::Range { from, .. } => from.oid,
+    pub fn from(oid: Oid) -> Self {
+        Self {
+            from: Some(oid),
+            to: None,
         }
     }
 
-    pub fn to(&self) -> Oid {
-        match self {
-            RevSpecPattern2::AtTag { to, .. } | RevSpecPattern2::Range { to, .. } => to.oid,
+    pub fn to(oid: Oid) -> Self {
+        Self {
+            from: None,
+            to: Some(oid),
+        }
+    }
+
+    pub fn full() -> Self {
+        Self {
+            from: None,
+            to: None,
         }
     }
 }
 
 impl Repository {
-    pub(super) fn revspec_from_str(&self, s: &str) -> Result<RevSpecPattern2, Git2Error> {
+    pub fn revspec_from_str(&self, s: &str) -> Result<RevSpecPattern2, Git2Error> {
         if let Some((from, to)) = s.split_once("..") {
             let from = if from.is_empty() {
-                CommitInfo::new(self.get_first_commit()?)
+                None
             } else {
-                self.get_commit_info(from)?
+                Some(self.parse_rev(from)?)
             };
 
             let to = if to.is_empty() {
-                self.get_cache().head_commit_info()
+                None
             } else {
-                self.get_commit_info(to)?
+                Some(self.parse_rev(to)?)
             };
 
-            Ok(RevSpecPattern2::Range { from, to })
+            Ok(RevSpecPattern2 { from, to })
         } else if let Ok(tag) = Tag::from_str(s, None) {
-            let previous = self.get_previous_tag(&tag)?.map(Into::into);
+            let previous = self.get_previous_tag(&tag)?.and_then(|tag| tag.oid);
 
-            let previous = match previous {
-                None => CommitInfo::new(self.get_first_commit()?),
-                Some(previous) => previous,
-            };
-
-            Ok(RevSpecPattern2::AtTag {
+            Ok(RevSpecPattern2 {
                 from: previous,
-                to: self.get_commit_info(s)?,
+                to: Some(self.parse_rev(s)?),
             })
         } else {
             Err(Git2Error::InvalidCommitRangePattern(s.to_string()))
         }
     }
 
-    pub(super) fn get_commit_info(&self, from: &str) -> Result<CommitInfo, Git2Error> {
-        let cache = self.get_cache();
-        let oid = cache
+    pub fn parse_rev(&self, from: &str) -> Result<Oid, Git2Error> {
+        self.get_cache()
             .refs
             .get(from)
             .copied()
             .or_else(|| Some(self.0.revparse_single(from).ok()?.id()))
-            .ok_or(Git2Error::UnknownRevision(from.to_string()))?;
-
-        Ok(cache
-            .commits
-            .get(&oid)
-            .cloned()
-            .unwrap_or(CommitInfo::new(oid)))
-    }
-}
-
-impl fmt::Display for RevSpecPattern2 {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        match self {
-            RevSpecPattern2::AtTag { from, to } | RevSpecPattern2::Range { from, to } => {
-                write!(f, "{from}..{to}")
-            }
-        }
+            .ok_or(Git2Error::UnknownRevision(from.to_string()))
     }
 }
 
 #[cfg(test)]
 mod test {
+    use crate::git::error::Git2Error;
     use crate::git::oid::CommitInfo;
+    use crate::git::repository::Repository;
     use crate::git::rev::revspec::RevSpecPattern2;
     use crate::git::tag::Tag;
     use crate::test_helpers::{commit, git_init_no_gpg, git_tag};
@@ -97,6 +83,19 @@ mod test {
     use sealed_test::prelude::*;
     use semver::Version;
     use speculoos::prelude::*;
+
+    impl Repository {
+        pub(super) fn get_commit_info(&self, from: &str) -> Result<CommitInfo, Git2Error> {
+            let oid = self.parse_rev(from)?;
+
+            Ok(self
+                .get_cache()
+                .commits
+                .get(&oid)
+                .cloned()
+                .unwrap_or(CommitInfo::new(oid)))
+        }
+    }
 
     #[sealed_test]
     fn should_resolve_tag_oid() -> Result<()> {
@@ -107,14 +106,12 @@ mod test {
 
         let oid = repo.get_commit_info("1.0.0")?;
 
-        let mut info = CommitInfo::from(Tag {
+        assert_that!(oid).is_equal_to(CommitInfo::from(Tag {
             package: None,
             prefix: None,
             version: Version::new(1, 0, 0),
             oid: Some(Oid::from_str(&commit_oid)?),
-        });
-        info.head = true;
-        assert_that!(oid).is_equal_to(info);
+        }));
 
         Ok(())
     }
@@ -127,9 +124,7 @@ mod test {
 
         let oid = repo.get_commit_info(&commit_oid)?;
 
-        let mut info = CommitInfo::new(Oid::from_str(&commit_oid)?);
-        info.head = true;
-        assert_that!(oid).is_equal_to(info);
+        assert_that!(oid).is_equal_to(CommitInfo::new(Oid::from_str(&commit_oid)?));
 
         Ok(())
     }
@@ -165,12 +160,15 @@ mod test {
     fn convert_str_to_pattern_to() -> Result<()> {
         let repo = git_init_no_gpg()?;
         commit("chore: first commit")?;
-        commit("chore: v1")?;
+        let sha_1 = commit("chore: v1")?;
         git_tag("1.0.0")?;
 
         let pattern = repo.revspec_from_str("..1.0.0")?;
 
-        assert_that!(matches!(pattern, RevSpecPattern2::Range { .. })).is_true();
+        assert_that!(pattern).is_equal_to(RevSpecPattern2 {
+            from: None,
+            to: Some(sha_1.parse().unwrap()),
+        });
         Ok(())
     }
 
@@ -178,13 +176,16 @@ mod test {
     fn convert_str_to_pattern_from() -> Result<()> {
         let repo = git_init_no_gpg()?;
         commit("chore: first commit")?;
-        commit("chore: v1")?;
+        let sha_1 = commit("chore: v1")?;
         git_tag("1.0.0")?;
         commit("chore: more commits")?;
 
         let pattern = repo.revspec_from_str("1.0.0..")?;
 
-        assert_that!(matches!(pattern, RevSpecPattern2::Range { .. })).is_true();
+        assert_that!(pattern).is_equal_to(RevSpecPattern2 {
+            from: Some(sha_1.parse().unwrap()),
+            to: None,
+        });
         Ok(())
     }
 
@@ -192,8 +193,13 @@ mod test {
     fn convert_empty_pattern() -> Result<()> {
         let repo = git_init_no_gpg()?;
         commit("chore: first commit")?;
+
         let pattern = repo.revspec_from_str("..")?;
-        assert_that!(matches!(pattern, RevSpecPattern2::Range { .. })).is_true();
+
+        assert_that!(pattern).is_equal_to(RevSpecPattern2 {
+            from: None,
+            to: None,
+        });
         Ok(())
     }
 
@@ -201,11 +207,14 @@ mod test {
     fn error_invalid_pattern() -> Result<()> {
         let repo = git_init_no_gpg()?;
         commit("chore: first commit")?;
-        commit("chore: v1")?;
+        let sha_1 = commit("chore: v1")?;
         git_tag("1.0.0")?;
         let pattern = repo.revspec_from_str("1.0.0")?;
 
-        assert_that!(matches!(pattern, RevSpecPattern2::AtTag { .. })).is_true();
+        assert_that!(pattern).is_equal_to(RevSpecPattern2 {
+            from: None,
+            to: Some(sha_1.parse().unwrap()),
+        });
         Ok(())
     }
 
@@ -214,14 +223,17 @@ mod test {
         let repo = git_init_no_gpg()?;
         commit("chore: first commit")?;
         commit("chore: first commit")?;
-        commit("chore: v1")?;
+        let sha_1 = commit("chore: v1")?;
         git_tag("1.0.0")?;
-        commit("chore: more commits")?;
+        let sha_2 = commit("chore: more commits")?;
         git_tag("2.0.0")?;
 
         let pattern = repo.revspec_from_str("1.0.0..2.0.0")?;
 
-        assert_that!(matches!(pattern, RevSpecPattern2::Range { .. })).is_true();
+        assert_that!(pattern).is_equal_to(RevSpecPattern2 {
+            from: Some(sha_1.parse().unwrap()),
+            to: Some(sha_2.parse().unwrap()),
+        });
         Ok(())
     }
 }

--- a/crates/cocogitto/src/git/rev/revwalk.rs
+++ b/crates/cocogitto/src/git/rev/revwalk.rs
@@ -4,6 +4,7 @@ use crate::git::error::Git2Error;
 use crate::git::oid::CommitInfo;
 use crate::git::repository::Repository;
 use crate::git::rev::filters::PackagePathFilter;
+use crate::git::rev::revspec::RevSpecPattern2;
 use crate::git::rev::CommitIter;
 use crate::SETTINGS;
 
@@ -11,7 +12,7 @@ impl Repository {
     /// Return a commit range for the given package from a [`RevspecPattern2`]
     pub fn get_commit_range_for_package(
         &self,
-        pattern: &str,
+        pattern: RevSpecPattern2,
         package: &str,
     ) -> Result<CommitIter<'_>, Git2Error> {
         let mut commit_range = self.revwalk(pattern)?;
@@ -65,7 +66,7 @@ impl Repository {
 
     pub fn get_commit_range_for_monorepo_global(
         &self,
-        pattern: &str,
+        pattern: RevSpecPattern2,
     ) -> Result<CommitIter<'_>, Git2Error> {
         let mut commit_range = self.revwalk(pattern)?;
         let mut commits = vec![];
@@ -119,35 +120,25 @@ impl Repository {
     }
 
     /// Return a commit range from a [`RevspecPattern2`]
-    pub fn revwalk(&self, spec: &str) -> Result<CommitIter<'_>, Git2Error> {
-        let spec = self.revspec_from_str(spec)?;
+    pub fn revwalk(&self, spec: RevSpecPattern2) -> Result<CommitIter<'_>, Git2Error> {
         let cache = self.get_cache();
 
-        if spec.from() == spec.to() {
-            let oid = spec.from();
-            let info = cache.get_info(oid);
-            let commit = self.0.find_commit(oid)?;
-            return Ok(CommitIter::single(info, commit));
+        let mut revwalk = self.0.revwalk()?;
+        if let Some(to) = spec.to {
+            revwalk.push(to)?;
+        } else {
+            revwalk.push_head()?;
+        }
+        if let Some(from) = spec.from {
+            revwalk.hide(from)?;
         }
 
-        let mut revwalk = self.0.revwalk()?;
-        revwalk.push_range(&spec.to_string())?;
-
         let mut commits: Vec<(CommitInfo, Commit)> = vec![];
-
         for oid in revwalk {
             let oid = oid?;
             let info = cache.get_info(oid);
             let commit = self.0.find_commit(oid)?;
             commits.push((info, commit));
-        }
-
-        // If the first commit in the range is the first commit of the repository (or head),
-        // assume it was meant to be an open ended range and add the commit
-        let first_info = cache.get_info(spec.from());
-        if first_info.head || first_info.first {
-            let first_commit = self.0.find_commit(spec.from())?;
-            commits.push((first_info, first_commit));
         }
 
         Ok(CommitIter(commits))
@@ -167,13 +158,22 @@ mod test {
     use speculoos::prelude::*;
 
     use crate::conventional::changelog::release::Release;
+    use crate::git::error::Git2Error;
     use crate::git::oid::CommitInfo;
     use crate::git::repository::Repository;
+    use crate::git::rev::revspec::RevSpecPattern2;
+    use crate::git::rev::CommitIter;
     use crate::git::tag::{Tag, TagLookUpOptions};
     use crate::settings::{MonoRepoPackage, Settings};
     use crate::test_helpers::{commit, git_init_no_gpg, git_tag, mkdir};
 
     const COCOGITTO_REPOSITORY: &str = env!("CARGO_MANIFEST_DIR");
+
+    impl Repository {
+        pub fn revwalk_pattern(&self, spec: &str) -> Result<CommitIter<'_>, Git2Error> {
+            self.revwalk(self.revspec_from_str(spec)?)
+        }
+    }
 
     #[test]
     fn all_commits() -> Result<()> {
@@ -181,7 +181,7 @@ mod test {
         let repo = Repository::open(COCOGITTO_REPOSITORY)?;
 
         // Act
-        let range = repo.revwalk("..")?;
+        let range = repo.revwalk_pattern("..")?;
 
         // Assert
         assert_that!(range.0).is_not_empty();
@@ -197,7 +197,7 @@ mod test {
         let three = commit("feat: feature 2")?;
         git_tag("0.1.0")?;
 
-        let range = repo.revwalk("0.1.0");
+        let range = repo.revwalk_pattern("0.1.0");
 
         let range = range?;
 
@@ -232,7 +232,7 @@ mod test {
         let five = commit("feat: feature 4")?;
         git_tag("0.2.0")?;
 
-        let range = repo.revwalk("..0.2.0")?;
+        let range = repo.revwalk_pattern("..0.2.0")?;
 
         // Act
         let release = Release::try_from(range)?;
@@ -269,7 +269,7 @@ mod test {
     fn get_release_range_integration_test() -> Result<()> {
         // Arrange
         let repo = Repository::open(COCOGITTO_REPOSITORY)?;
-        let range = repo.revwalk("0.32.1..0.32.3")?;
+        let range = repo.revwalk_pattern("0.32.1..0.32.3")?;
 
         // Act
         let release = Release::try_from(range)?;
@@ -300,12 +300,10 @@ mod test {
         commit("feat: a commit")?;
 
         // Act
-        let commit_range = repo.revwalk("..1.0.0")?;
+        let commit_range = repo.revwalk_pattern("..1.0.0")?;
 
         // Assert
-        let mut info = CommitInfo::new(Oid::from_str(&first)?);
-        info.first = true;
-        assert_that!(commit_range.from_oid()).is_equal_to(info);
+        assert_that!(commit_range.from_oid()).is_equal_to(CommitInfo::new(Oid::from_str(&first)?));
         assert_that!(commit_range.to_oid().to_string()).is_equal_to("1.0.0".to_string());
         assert_that!(commit_range.0).has_length(2);
         Ok(())
@@ -348,8 +346,10 @@ mod test {
             git commit -m "feat: global change";
         )?;
 
-        let commit_range_package = repo.get_commit_range_for_package("..HEAD", "one")?;
-        let commit_range_global = repo.get_commit_range_for_monorepo_global("..HEAD");
+        let commit_range_package =
+            repo.get_commit_range_for_package(RevSpecPattern2::full(), "one")?;
+        let commit_range_global =
+            repo.get_commit_range_for_monorepo_global(RevSpecPattern2::full());
         let commit_range_global = commit_range_global?;
         assert_that!(commit_range_package.0).has_length(1);
         assert_that!(commit_range_global.0).has_length(2);
@@ -366,7 +366,8 @@ mod test {
             git commit -m "feat: commit to non-ignored path";
         )?;
 
-        let commit_range_package = repo.get_commit_range_for_package("HEAD~1..HEAD", "one")?;
+        let commit_range_package =
+            repo.get_commit_range_for_package(repo.revspec_from_str("HEAD~1..HEAD")?, "one")?;
 
         asserting!("package with changes have some commits")
             .that(&commit_range_package.0)
@@ -388,7 +389,8 @@ mod test {
             git commit -m "feat: commit to ignored path";
         )?;
 
-        let commit_range_package = repo.get_commit_range_for_package("HEAD~1..HEAD", "one")?;
+        let commit_range_package =
+            repo.get_commit_range_for_package(repo.revspec_from_str("HEAD~1..HEAD")?, "one")?;
 
         asserting!("package with no changes should have some commits for HEAD~1 revspec")
             .that(&commit_range_package.0)
@@ -407,7 +409,8 @@ mod test {
             git commit -m "feat: commit to extra included path";
         )?;
 
-        let commit_range_package = repo.get_commit_range_for_package("HEAD~1..HEAD", "one")?;
+        let commit_range_package =
+            repo.get_commit_range_for_package(repo.revspec_from_str("HEAD~1..HEAD")?, "one")?;
 
         asserting!("package with shared changes should have some commits for HEAD~1 revspec")
             .that(&commit_range_package.0)
@@ -431,7 +434,8 @@ mod test {
             git commit -m "feat: commit to extra included file";
         )?;
 
-        let commit_range_package = repo.get_commit_range_for_package("HEAD~1..HEAD", "one")?;
+        let commit_range_package =
+            repo.get_commit_range_for_package(repo.revspec_from_str("HEAD~1..HEAD")?, "one")?;
 
         asserting!(
             "package with extra included changes should have some commits for HEAD~1 revspec"
@@ -450,7 +454,8 @@ mod test {
     #[sealed_test]
     fn package_with_with_only_ignored_path_should_have_no_commit() -> Result<()> {
         let repo = init_mono_repo_for_range_filtering()?;
-        let commit_range_package = repo.get_commit_range_for_package("..HEAD", "one")?;
+        let commit_range_package =
+            repo.get_commit_range_for_package(RevSpecPattern2::full(), "one")?;
         asserting!("package with with only ignored path commit should have no commits for full range revspec")
             .that(&commit_range_package.0).has_length(0);
 
@@ -501,7 +506,7 @@ mod test {
         commit("feat: a commit")?;
 
         // Act
-        let commit_range = repo.revwalk("..1.0.0")?;
+        let commit_range = repo.revwalk_pattern("..1.0.0")?;
 
         // Assert
         assert_that!(commit_range.from_oid().to_string()).is_equal_to(first);
@@ -520,7 +525,7 @@ mod test {
         let v3_0_0 = CommitInfo::from(Tag::from_str("3.0.0", Some(v3_0_0))?);
 
         // Act
-        let range = repo.revwalk("1.0.0..3.0.0")?;
+        let range = repo.revwalk_pattern("1.0.0..3.0.0")?;
 
         // Assert
         assert_that!(range.from_oid().to_string())
@@ -535,8 +540,7 @@ mod test {
         // Arrange
         let repo = Repository::open(COCOGITTO_REPOSITORY)?;
         let head = repo.get_head_commit_oid()?;
-        let mut head = CommitInfo::new(head);
-        head.head = true;
+        let head = CommitInfo::new(head);
         let tag = repo.get_latest_tag(TagLookUpOptions::default())?;
 
         // Cover the case when we release a version and run the test in the CI right after that
@@ -550,7 +554,7 @@ mod test {
         let _v1_0_0 = CommitInfo::from(Tag::from_str("1.0.0", Some(v1_0_0))?);
 
         // Act
-        let range = repo.revwalk("1.0.0..")?;
+        let range = repo.revwalk_pattern("1.0.0..")?;
 
         // Assert
         assert_that!(range.from_oid().oid)
@@ -570,7 +574,7 @@ mod test {
         let v3_0_0 = CommitInfo::from(Tag::from_str("3.0.0", Some(v3_0_0))?);
 
         // Act
-        let range = repo.revwalk("2.1.1..3.0.0")?;
+        let range = repo.revwalk_pattern("2.1.1..3.0.0")?;
 
         // Assert
         assert_that!(range.from_oid().oid)
@@ -584,14 +588,21 @@ mod test {
     fn recursive_from_origin_to_head() -> Result<()> {
         // Arrange
         let repo = Repository::open(COCOGITTO_REPOSITORY)?;
-        let mut tag_count = repo.0.tag_names(None)?.len();
+        // filter tags to only count global tags (starting with major version = digit)
+        let mut tag_count = repo
+            .0
+            .tag_names(None)?
+            .iter()
+            .filter_map(|tag| tag)
+            .filter(|tag| tag.starts_with(|c: char| c.is_ascii_digit()))
+            .count();
         let head = repo.get_head_commit_oid()?;
         let latest = repo.get_latest_tag(TagLookUpOptions::default())?;
         if latest.oid == Some(head) {
             tag_count -= 1;
         };
 
-        let range = repo.revwalk("..")?;
+        let range = repo.revwalk_pattern("..")?;
 
         // Act
         let mut release = Release::try_from(range)?;
@@ -620,7 +631,7 @@ mod test {
         let three = commit("chore: 1.0.0")?;
         let four = commit("fix: the bug")?;
 
-        let range = repo.revwalk(&format!("{}..", &one[0..7]))?;
+        let range = repo.revwalk_pattern(&format!("{}..", &one[0..7]))?;
 
         // Act
         let release = Release::try_from(range)?;
@@ -651,7 +662,7 @@ mod test {
         git_tag("1.0.0")?;
         let three = commit("fix: the bug")?;
 
-        let range = repo.revwalk(&format!("{}..", &from[0..7]))?;
+        let range = repo.revwalk_pattern(&format!("{}..", &from[0..7]))?;
 
         // Act
         let release = Release::try_from(range)?;

--- a/crates/cocogitto/src/git/rev/revwalk.rs
+++ b/crates/cocogitto/src/git/rev/revwalk.rs
@@ -1,7 +1,7 @@
 use git2::Commit;
 
 use crate::git::error::Git2Error;
-use crate::git::oid::OidOf;
+use crate::git::oid::CommitInfo;
 use crate::git::repository::Repository;
 use crate::git::rev::filters::PackagePathFilter;
 use crate::git::rev::CommitIter;
@@ -14,7 +14,7 @@ impl Repository {
         pattern: &str,
         package: &str,
     ) -> Result<CommitIter<'_>, Git2Error> {
-        let mut commit_range = self.revwalk_pkg(pattern, Some(package))?;
+        let mut commit_range = self.revwalk(pattern)?;
         let mut commits = vec![];
         let package = SETTINGS
             .monorepo
@@ -120,46 +120,34 @@ impl Repository {
 
     /// Return a commit range from a [`RevspecPattern2`]
     pub fn revwalk(&self, spec: &str) -> Result<CommitIter<'_>, Git2Error> {
-        self.revwalk_pkg(spec, None)
-    }
-
-    pub fn revwalk_pkg(
-        &self,
-        spec: &str,
-        package: Option<&str>,
-    ) -> Result<CommitIter<'_>, Git2Error> {
         let spec = self.revspec_from_str(spec)?;
+        let cache = self.get_cache();
 
         if spec.from() == spec.to() {
-            let oid = *spec.from();
-            let oid_of = self.resolve_oid_of(&oid.to_string())?;
+            let oid = spec.from();
+            let info = cache.get_info(oid);
             let commit = self.0.find_commit(oid)?;
-            return Ok(CommitIter::single(oid_of, commit));
+            return Ok(CommitIter::single(info, commit));
         }
 
         let mut revwalk = self.0.revwalk()?;
         revwalk.push_range(&spec.to_string())?;
 
-        let mut commits: Vec<(OidOf, Commit)> = vec![];
+        let mut commits: Vec<(CommitInfo, Commit)> = vec![];
 
         for oid in revwalk {
             let oid = oid?;
-            // TODO: can we avoid allocating strings here ?
-            let oid_of = self.resolve_oid_of_package(&oid.to_string(), package)?;
+            let info = cache.get_info(oid);
             let commit = self.0.find_commit(oid)?;
-            commits.push((oid_of, commit));
+            commits.push((info, commit));
         }
 
-        // TODO: can we avoid allocating strings here ?
-        let first_oid = self.resolve_oid_of_package(&spec.from().to_string(), package)?;
-        let include_start = match &first_oid {
-            OidOf::Head(_) | OidOf::FirstCommit(_) => true,
-            OidOf::Tag(_) | OidOf::Other(_) => false,
-        };
-
-        if include_start {
-            let first_commit = self.0.find_commit(*spec.from())?;
-            commits.push((first_oid, first_commit));
+        // If the first commit in the range is the first commit of the repository (or head),
+        // assume it was meant to be an open ended range and add the commit
+        let first_info = cache.get_info(spec.from());
+        if first_info.head || first_info.first {
+            let first_commit = self.0.find_commit(spec.from())?;
+            commits.push((first_info, first_commit));
         }
 
         Ok(CommitIter(commits))
@@ -179,7 +167,7 @@ mod test {
     use speculoos::prelude::*;
 
     use crate::conventional::changelog::release::Release;
-    use crate::git::oid::OidOf;
+    use crate::git::oid::CommitInfo;
     use crate::git::repository::Repository;
     use crate::git::tag::{Tag, TagLookUpOptions};
     use crate::settings::{MonoRepoPackage, Settings};
@@ -218,8 +206,8 @@ mod test {
 
         // Assert
         assert_that!(release.previous).is_none();
-        assert_that!(release.version.oid()).is_equal_to(&Oid::from_str(&three)?);
-        assert_that!(release.from).is_equal_to(OidOf::FirstCommit(Oid::from_str(&one)?));
+        assert_that!(release.version.id).is_equal_to(&Oid::from_str(&three)?);
+        assert_that!(release.from.id).is_equal_to(&Oid::from_str(&one)?);
 
         let expected_commits: Vec<String> = release
             .commits
@@ -315,8 +303,9 @@ mod test {
         let commit_range = repo.revwalk("..1.0.0")?;
 
         // Assert
-        assert_that!(commit_range.from_oid())
-            .is_equal_to(OidOf::FirstCommit(Oid::from_str(&first)?));
+        let mut info = CommitInfo::new(Oid::from_str(&first)?);
+        info.first = true;
+        assert_that!(commit_range.from_oid()).is_equal_to(info);
         assert_that!(commit_range.to_oid().to_string()).is_equal_to("1.0.0".to_string());
         assert_that!(commit_range.0).has_length(2);
         Ok(())
@@ -526,9 +515,9 @@ mod test {
         // Arrange
         let repo = Repository::open(COCOGITTO_REPOSITORY)?;
         let v1_0_0 = Oid::from_str("549070fa99986b059cbaa9457b6b6f065bbec46b")?;
-        let _v1_0_0 = OidOf::Tag(Tag::from_str("1.0.0", Some(v1_0_0))?);
+        let _v1_0_0 = CommitInfo::from(Tag::from_str("1.0.0", Some(v1_0_0))?);
         let v3_0_0 = Oid::from_str("c6508e243e2816e2d2f58828ee0c6721502958dd")?;
-        let v3_0_0 = OidOf::Tag(Tag::from_str("3.0.0", Some(v3_0_0))?);
+        let v3_0_0 = CommitInfo::from(Tag::from_str("3.0.0", Some(v3_0_0))?);
 
         // Act
         let range = repo.revwalk("1.0.0..3.0.0")?;
@@ -546,24 +535,25 @@ mod test {
         // Arrange
         let repo = Repository::open(COCOGITTO_REPOSITORY)?;
         let head = repo.get_head_commit_oid()?;
-        let head = OidOf::Head(head);
+        let mut head = CommitInfo::new(head);
+        head.head = true;
         let tag = repo.get_latest_tag(TagLookUpOptions::default())?;
 
         // Cover the case when we release a version and run the test in the CI right after that
-        let head = if tag.oid() == Some(head.oid()) {
-            OidOf::Tag(tag)
+        let head = if tag.oid == Some(head.oid) {
+            CommitInfo::from(tag)
         } else {
             head
         };
 
         let v1_0_0 = Oid::from_str("549070fa99986b059cbaa9457b6b6f065bbec46b")?;
-        let _v1_0_0 = OidOf::Tag(Tag::from_str("1.0.0", Some(v1_0_0))?);
+        let _v1_0_0 = CommitInfo::from(Tag::from_str("1.0.0", Some(v1_0_0))?);
 
         // Act
         let range = repo.revwalk("1.0.0..")?;
 
         // Assert
-        assert_that!(range.from_oid().oid())
+        assert_that!(range.from_oid().oid)
             .is_equal_to(&Oid::from_str("7c4a1cb692b445f36a44857ce17db32b91acd24c")?);
         assert_that!(range.to_oid()).is_equal_to(head);
 
@@ -575,17 +565,45 @@ mod test {
         // Arrange
         let repo = Repository::open(COCOGITTO_REPOSITORY)?;
         let v2_1_1 = Oid::from_str("9dcf728d2eef6b5986633dd52ecbe9e416234898")?;
-        let _v2_1_1 = OidOf::Tag(Tag::from_str("2.1.1", Some(v2_1_1))?);
+        let _v2_1_1 = CommitInfo::from(Tag::from_str("2.1.1", Some(v2_1_1))?);
         let v3_0_0 = Oid::from_str("c6508e243e2816e2d2f58828ee0c6721502958dd")?;
-        let v3_0_0 = OidOf::Tag(Tag::from_str("3.0.0", Some(v3_0_0))?);
+        let v3_0_0 = CommitInfo::from(Tag::from_str("3.0.0", Some(v3_0_0))?);
 
         // Act
         let range = repo.revwalk("2.1.1..3.0.0")?;
 
         // Assert
-        assert_that!(range.from_oid().oid())
+        assert_that!(range.from_oid().oid)
             .is_equal_to(&Oid::from_str("434c22295390fda0f276e3a3ee32fa4658489c5d")?);
         assert_that!(range.to_oid()).is_equal_to(v3_0_0);
+
+        Ok(())
+    }
+
+    #[test]
+    fn recursive_from_origin_to_head() -> Result<()> {
+        // Arrange
+        let repo = Repository::open(COCOGITTO_REPOSITORY)?;
+        let mut tag_count = repo.0.tag_names(None)?.len();
+        let head = repo.get_head_commit_oid()?;
+        let latest = repo.get_latest_tag(TagLookUpOptions::default())?;
+        if latest.oid == Some(head) {
+            tag_count -= 1;
+        };
+
+        let range = repo.revwalk("..")?;
+
+        // Act
+        let mut release = Release::try_from(range)?;
+        let mut count = 0;
+
+        while let Some(previous) = release.previous {
+            release = *previous;
+            count += 1;
+        }
+
+        // Assert
+        assert_that!(count).is_equal_to(tag_count);
 
         Ok(())
     }

--- a/crates/cocogitto/src/git/tag.rs
+++ b/crates/cocogitto/src/git/tag.rs
@@ -7,7 +7,6 @@ use semver::Version;
 
 use crate::conventional::version::Increment;
 use crate::git::error::{Git2Error, TagError};
-use crate::git::oid::OidOf;
 use crate::git::repository::Repository;
 use crate::SETTINGS;
 
@@ -129,10 +128,9 @@ impl Repository {
 
     pub fn tag_lookup(&self, option: TagLookUpOptions) -> Result<Vec<Tag>, TagError> {
         let prefix = SETTINGS.tag_prefix.as_ref();
-        let repo_cache = crate::git::rev::cache::get_cache(self);
         let include_pre_release = option.include_pre_release;
 
-        let tag_filter = |tag: &Tag| {
+        let tag_filter = |tag: &&Tag| {
             tag.prefix.as_ref() == prefix
                 && tag.package.as_deref() == option.package_name
                 && option.include_packages != tag.package.is_none()
@@ -143,13 +141,11 @@ impl Repository {
                 }
         };
 
-        Ok(repo_cache
-            .values()
-            .flatten()
-            .filter_map(|oid| match oid {
-                OidOf::Tag(tag) if tag_filter(tag) => Some(tag),
-                _ => None,
-            })
+        Ok(self
+            .get_cache()
+            .tags
+            .iter()
+            .filter(tag_filter)
             .cloned()
             .collect())
     }
@@ -213,10 +209,6 @@ impl Tag {
             version,
             oid: None,
         }
-    }
-
-    pub(crate) fn oid(&self) -> Option<&Oid> {
-        self.oid.as_ref()
     }
 
     pub fn from_str(raw: &str, oid: Option<Oid>) -> Result<Tag, TagError> {

--- a/crates/cocogitto/src/lib.rs
+++ b/crates/cocogitto/src/lib.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashMap};
+use std::collections::HashMap;
 use std::fs::File;
 use std::io::{self, BufRead};
 use std::path::PathBuf;
@@ -20,7 +20,6 @@ use git::repository::Repository;
 use settings::Settings;
 
 use crate::git::error::{Git2Error, TagError};
-use crate::git::rev::cache::get_cache;
 
 use crate::git::tag::Tag;
 
@@ -193,8 +192,7 @@ impl CocoGitto {
 
     // Currently only used in test to force rebuild the tag cache
     pub fn clear_cache(&self) {
-        let mut cache = get_cache(&self.repository);
-        *cache = BTreeMap::new();
+        self.repository.get_cache().clear();
     }
 }
 

--- a/crates/cocogitto/src/lib.rs
+++ b/crates/cocogitto/src/lib.rs
@@ -31,6 +31,7 @@ pub mod hook;
 pub mod log;
 /// Settings module containing configuration structures and functions for Cocogitto
 pub mod settings;
+pub mod target;
 
 pub const DEFAULT_CONFIG_PATH: &str = "cog.toml";
 static CONFIG_PATH: OnceLock<String> = OnceLock::new();

--- a/crates/cocogitto/src/settings/mod.rs
+++ b/crates/cocogitto/src/settings/mod.rs
@@ -16,6 +16,7 @@ use crate::settings::error::SettingError;
 use config::{Config, File, FileFormat};
 use conventional_commit_parser::commit::CommitType;
 use maplit::hashmap;
+use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 
@@ -565,6 +566,14 @@ impl Settings {
         repository: T,
     ) -> Result<Self, SettingError> {
         repository.try_into()
+    }
+
+    pub(crate) fn list_packages(&self) -> &HashMap<String, MonoRepoPackage> {
+        static EMPTY_PACKAGES: Lazy<HashMap<String, MonoRepoPackage>> = Lazy::new(HashMap::new);
+        self.monorepo
+            .as_ref()
+            .map(|mr| &mr.packages)
+            .unwrap_or(&*EMPTY_PACKAGES)
     }
 
     /// Loads and merges commit types configuration.

--- a/crates/cocogitto/src/target.rs
+++ b/crates/cocogitto/src/target.rs
@@ -1,0 +1,135 @@
+use crate::{settings::MonoRepoPackage, SETTINGS};
+
+/// The target of a cocogitto execution
+///
+/// mainly used for bumping and changelogs
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum Target {
+    /// The non-monorepo target
+    Standard,
+    /// A single package
+    Package {
+        name: &'static str,
+        package: &'static MonoRepoPackage,
+    },
+    /// The monorepo global (non-package) target
+    Monorepo { manual: bool },
+    /// A combination of the global target and all package targets
+    ///
+    /// Similar to [`Standard`](Target::Standard), but in a monorepo
+    Unified { manual: bool },
+}
+
+impl Target {
+    pub fn from_options(package: Option<&str>, manual: bool, unified: bool) -> Self {
+        if SETTINGS.list_packages().is_empty() {
+            Self::Standard
+        } else if let Some(name) = package {
+            Self::package(name)
+        } else if unified {
+            Self::Unified { manual }
+        } else {
+            Self::Monorepo { manual }
+        }
+    }
+
+    pub fn package(name: &str) -> Self {
+        // use iter() + find() instead of packages[name] to get static lifetime for name
+        let (name, package) = SETTINGS
+            .list_packages()
+            .iter()
+            .find(|(key, _)| *key == name)
+            .expect("invalid package");
+        Self::Package { name, package }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::test_helpers::git_init_no_gpg;
+
+    use anyhow::Result;
+    use sealed_test::prelude::*;
+    use speculoos::assert_that;
+
+    #[sealed_test]
+    fn resolves_package_target() -> Result<()> {
+        // Arrange
+        git_init_no_gpg()?;
+        std::fs::write("cog.toml", "monorepo.packages.pkg.path = \"pkg\"")?;
+
+        // Act
+        let target = Target::package("pkg");
+
+        // Assert
+        assert_that!(target).matches(|target| matches!(target, Target::Package { .. }));
+
+        Ok(())
+    }
+
+    #[sealed_test]
+    fn always_standard_outside_monorepo() -> Result<()> {
+        // Arrange
+        git_init_no_gpg()?;
+
+        // Act
+        let target_pkg = Target::from_options(Some("pkg"), false, false);
+        let target_manual = Target::from_options(None, true, false);
+        let target_unified = Target::from_options(None, false, true);
+        let target_all = Target::from_options(Some("pkg"), true, true);
+
+        // Assert
+        assert_that!(target_pkg).is_equal_to(Target::Standard);
+        assert_that!(target_manual).is_equal_to(Target::Standard);
+        assert_that!(target_unified).is_equal_to(Target::Standard);
+        assert_that!(target_all).is_equal_to(Target::Standard);
+
+        Ok(())
+    }
+
+    #[sealed_test]
+    fn resolve_package_option() -> Result<()> {
+        // Arrange
+        git_init_no_gpg()?;
+        std::fs::write("cog.toml", "monorepo.packages.pkg.path = \"pkg\"")?;
+
+        // Act
+        let target = Target::from_options(Some("pkg"), false, false);
+
+        // Assert
+        assert_that!(target).matches(|t| matches!(t, Target::Package { .. }));
+
+        Ok(())
+    }
+
+    #[sealed_test]
+    fn resolve_unified_option() -> Result<()> {
+        // Arrange
+        git_init_no_gpg()?;
+        std::fs::write("cog.toml", "monorepo.packages.pkg.path = \"pkg\"")?;
+
+        // Act
+        let target = Target::from_options(None, false, true);
+
+        // Assert
+        assert_that!(target).is_equal_to(Target::Unified { manual: false });
+
+        Ok(())
+    }
+
+    #[sealed_test]
+    fn resolve_manual_option() -> Result<()> {
+        // Arrange
+        git_init_no_gpg()?;
+        std::fs::write("cog.toml", "monorepo.packages.pkg.path = \"pkg\"")?;
+
+        // Act
+        let target = Target::from_options(None, true, false);
+
+        // Assert
+        assert_that!(target).is_equal_to(Target::Monorepo { manual: true });
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
This implements change (1) described in #565 

- `OidOf` is replaced with `CommitInfo` and `ReleaseVersion`. As `CommitInfo` now holds tags for all packages, `Repository::revwalk_pkg()` is no longer needed. Instead, `Release::build_package()` exists.

  With this, the tag cache has also been restructured to hold two `HashMap`s: git reference -> oid and oid -> `CommitInfo`. This allows multiple references to point to the same `CommitInfo`.
- `RevSpecPatternV2` is now a struct (instead of enum) and has `Option<Oid>` as type for `from` and `to`,  mirroring git ranges (which can be open on both ends). Also, the type is used more often througout the code to avoid formatting and parsing the same range multiple times.
- The `Target` type has been added.

  This type isn't used right now, but will be used a lot in following PRs (for example to replace `ReleaseType`). As it will become a core type, it felt more fitting to include it in the first change (see #565)